### PR TITLE
Ordering for complex types

### DIFF
--- a/core/src/main/scala/scraper/RowOrdering.scala
+++ b/core/src/main/scala/scraper/RowOrdering.scala
@@ -5,9 +5,7 @@ import scraper.expressions.BoundRef.bind
 import scraper.types.{DataType, OrderedType}
 
 class NullSafeOrdering(dataType: DataType, nullsLarger: Boolean) extends Ordering[Any] {
-  private val baseOrdering = dataType match {
-    case t: OrderedType => t.genericOrdering
-  }
+  private val baseOrdering = OrderedType.orderingOf(dataType)
 
   override def compare(lhs: Any, rhs: Any): Int = (lhs, rhs) match {
     case (null, null) => 0

--- a/core/src/main/scala/scraper/expressions/Cast.scala
+++ b/core/src/main/scala/scraper/expressions/Cast.scala
@@ -197,9 +197,9 @@ object Cast {
    * already of the target type, `e` is returned untouched.
    */
   def promoteDataType(e: Expression, dataType: DataType): Expression = e match {
-    case _ if e.dataType == dataType             => e
-    case _ if e.dataType compatibleWith dataType => e cast dataType
-    case _                                       => throw new ImplicitCastException(e, dataType)
+    case _ if e.dataType == dataType               => e
+    case _ if e.dataType isCompatibleWith dataType => e cast dataType
+    case _                                         => throw new ImplicitCastException(e, dataType)
   }
 
   /**

--- a/core/src/main/scala/scraper/expressions/Literal.scala
+++ b/core/src/main/scala/scraper/expressions/Literal.scala
@@ -1,6 +1,6 @@
 package scraper.expressions
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 import scraper.Row
 import scraper.types._
@@ -12,7 +12,7 @@ case class Literal(value: Any, override val dataType: PrimitiveType) extends Lea
 
   override def debugString: String = s"$value:${dataType.sql}"
 
-  override def sql: Try[String] = Success((value, dataType) match {
+  override def sql: Try[String] = Try((value, dataType) match {
     case (v: String, StringType)   => '"' + v.replace("\\", "\\\\").replace("\"", "\\\"") + '"'
     case (v: Boolean, BooleanType) => v.toString.toUpperCase
     case (v: Byte, ByteType)       => s"CAST($v AS ${ByteType.sql})"

--- a/core/src/main/scala/scraper/expressions/comparisons.scala
+++ b/core/src/main/scala/scraper/expressions/comparisons.scala
@@ -8,9 +8,7 @@ trait BinaryComparison extends BinaryOperator {
   override def dataType: DataType = BooleanType
 
   protected lazy val ordering: Ordering[Any] = whenStrictlyTyped {
-    left.dataType match {
-      case t: OrderedType => t.genericOrdering
-    }
+    OrderedType.orderingOf(left.dataType)
   }
 
   override protected lazy val typeConstraint: TypeConstraint = children sameSubtypeOf OrderedType
@@ -75,14 +73,7 @@ case class In(test: Expression, list: Seq[Expression]) extends Expression {
   override def evaluate(input: Row): Any = {
     val testValue = test evaluate input
     val listValues = list map (_ evaluate input)
-
-    dataType match {
-      case t: OrderedType =>
-        listValues exists (t.genericOrdering.compare(testValue, _) == 0)
-
-      case _ =>
-        false
-    }
+    listValues contains testValue
   }
 
   override protected def template(childList: Seq[String]): String = {

--- a/core/src/main/scala/scraper/expressions/typecheck/TypeConstraint.scala
+++ b/core/src/main/scala/scraper/expressions/typecheck/TypeConstraint.scala
@@ -62,8 +62,8 @@ case class SameTypeAs(targetType: DataType, input: Seq[Expression]) extends Type
   override def enforced: Try[Seq[Expression]] = for {
     strictArgs <- trySequence(input map (_.strictlyTyped))
   } yield strictArgs map {
-    case e if e.dataType compatibleWith targetType => promoteDataType(e, targetType)
-    case e                                         => throw new TypeMismatchException(e, targetType)
+    case e if e.dataType isCompatibleWith targetType => promoteDataType(e, targetType)
+    case e => throw new TypeMismatchException(e, targetType)
   }
 }
 
@@ -80,7 +80,7 @@ case class SameSubtypesOf(supertype: AbstractDataType, input: Seq[Expression])
     strictArgs <- trySequence(input map (_.strictlyTyped))
 
     // Finds all expressions whose data types are already subtype of `superType`.
-    candidates = for (e <- strictArgs if e.dataType subtypeOf supertype) yield e
+    candidates = for (e <- strictArgs if e.dataType isSubtypeOf supertype) yield e
 
     // Ensures that there's at least one expression whose data type is directly a subtype of
     // `superType`. In this way, expressions like

--- a/core/src/main/scala/scraper/plans/logical/LogicalPlan.scala
+++ b/core/src/main/scala/scraper/plans/logical/LogicalPlan.scala
@@ -140,7 +140,7 @@ case class Limit(child: LogicalPlan, limit: Expression) extends UnaryLogicalPlan
       case e if e.isFoldable && e.dataType == IntType =>
         Literal(e.evaluated, IntType)
 
-      case e if e.isFoldable && (e.dataType castableTo IntType) =>
+      case e if e.isFoldable && (e.dataType isCastableTo IntType) =>
         Literal(e.evaluated) cast IntType
 
       case _ =>

--- a/core/src/main/scala/scraper/types/DataType.scala
+++ b/core/src/main/scala/scraper/types/DataType.scala
@@ -8,7 +8,7 @@ import scraper.expressions.Cast.{castable, compatible}
 import scraper.trees.TreeNode
 
 trait DataType { self =>
-  def genericOrdering: Option[Ordering[Any]] = None
+  def genericOrdering: Option[Ordering[Any]]
 
   /** Returns a nullable [[FieldSpec]] of this [[DataType]]. */
   def ? : FieldSpec = FieldSpec(this, nullable = true)
@@ -181,7 +181,7 @@ case object NullType extends PrimitiveType {
 case object StringType extends PrimitiveType {
   override type InternalType = String
 
-  override val ordering: Option[Ordering[String]] = Some(implicitly[Ordering[String]])
+  override val ordering: Option[Ordering[String]] = Some(Ordering.String)
 
   override def sql: String = "STRING"
 }
@@ -189,7 +189,7 @@ case object StringType extends PrimitiveType {
 case object BooleanType extends PrimitiveType {
   override type InternalType = Boolean
 
-  override val ordering: Option[Ordering[Boolean]] = Some(implicitly[Ordering[Boolean]])
+  override val ordering: Option[Ordering[Boolean]] = Some(Ordering.Boolean)
 
   override def sql: String = "BOOLEAN"
 }

--- a/core/src/main/scala/scraper/types/complexTypes.scala
+++ b/core/src/main/scala/scraper/types/complexTypes.scala
@@ -12,7 +12,7 @@ trait ComplexType extends DataType
 object ComplexType extends AbstractDataType {
   override val defaultType: Option[DataType] = None
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: ComplexType => true
     case _              => false
   }
@@ -33,7 +33,7 @@ object ArrayType extends AbstractDataType {
 
   override val defaultType: Option[DataType] = None
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: ArrayType => true
     case _            => false
   }
@@ -53,7 +53,7 @@ object MapType extends AbstractDataType {
 
   override val defaultType: Option[DataType] = None
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: MapType => true
     case _          => false
   }
@@ -135,7 +135,7 @@ object StructType extends AbstractDataType {
 
   override val defaultType: Option[DataType] = None
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: StructType => true
     case _             => false
   }

--- a/core/src/main/scala/scraper/types/numericTypes.scala
+++ b/core/src/main/scala/scraper/types/numericTypes.scala
@@ -9,7 +9,7 @@ trait NumericType extends PrimitiveType {
 object NumericType extends AbstractDataType {
   override val defaultType: Option[DataType] = Some(DoubleType)
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: NumericType => true
     case _              => false
   }
@@ -26,7 +26,7 @@ trait IntegralType extends NumericType {
 object IntegralType extends AbstractDataType {
   val defaultType: Option[DataType] = Some(IntType)
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: IntegralType => true
     case _               => false
   }
@@ -91,7 +91,7 @@ trait FractionalType extends NumericType {
 object FractionalType extends AbstractDataType {
   val defaultType: Option[DataType] = Some(DoubleType)
 
-  override def supertypeOf(dataType: DataType): Boolean = dataType match {
+  override def isSupertypeOf(dataType: DataType): Boolean = dataType match {
     case _: FractionalType => true
     case _                 => false
   }

--- a/core/src/main/scala/scraper/types/numericTypes.scala
+++ b/core/src/main/scala/scraper/types/numericTypes.scala
@@ -41,7 +41,7 @@ case object ByteType extends IntegralType {
 
   override val numeric: Numeric[Byte] = implicitly[Numeric[Byte]]
 
-  override val ordering: Option[Ordering[Byte]] = Some(implicitly[Ordering[Byte]])
+  override val ordering: Option[Ordering[Byte]] = Some(Ordering.Byte)
 
   override def sql: String = "TINYINT"
 }
@@ -53,7 +53,7 @@ case object ShortType extends IntegralType {
 
   override val numeric: Numeric[Short] = implicitly[Numeric[Short]]
 
-  override val ordering: Option[Ordering[Short]] = Some(implicitly[Ordering[Short]])
+  override val ordering: Option[Ordering[Short]] = Some(Ordering.Short)
 
   override def sql: String = "SMALLINT"
 }
@@ -65,7 +65,7 @@ case object IntType extends IntegralType {
 
   override val numeric: Numeric[Int] = implicitly[Numeric[Int]]
 
-  override val ordering: Option[Ordering[Int]] = Some(implicitly[Ordering[Int]])
+  override val ordering: Option[Ordering[Int]] = Some(Ordering.Int)
 
   override def sql: String = "INT"
 }
@@ -77,7 +77,7 @@ case object LongType extends IntegralType {
 
   override val numeric: Numeric[Long] = implicitly[Numeric[Long]]
 
-  override val ordering: Option[Ordering[Long]] = Some(implicitly[Ordering[Long]])
+  override val ordering: Option[Ordering[Long]] = Some(Ordering.Long)
 
   override def sql: String = "BIGINT"
 }
@@ -106,7 +106,7 @@ case object FloatType extends FractionalType {
 
   override val numeric: Numeric[Float] = implicitly[Numeric[Float]]
 
-  override val ordering: Option[Ordering[Float]] = Some(implicitly[Ordering[Float]])
+  override val ordering: Option[Ordering[Float]] = Some(Ordering.Float)
 
   override def sql: String = "FLOAT"
 }
@@ -118,7 +118,7 @@ case object DoubleType extends FractionalType {
 
   override val numeric: Numeric[Double] = implicitly[Numeric[Double]]
 
-  override val ordering: Option[Ordering[Double]] = Some(implicitly[Ordering[Double]])
+  override val ordering: Option[Ordering[Double]] = Some(Ordering.Double)
 
   override def sql: String = "DOUBLE"
 }

--- a/core/src/main/scala/scraper/types/numericTypes.scala
+++ b/core/src/main/scala/scraper/types/numericTypes.scala
@@ -1,6 +1,6 @@
 package scraper.types
 
-trait NumericType extends PrimitiveType with OrderedType {
+trait NumericType extends PrimitiveType {
   val numeric: Numeric[InternalType]
 
   def genericNumeric: Numeric[Any] = numeric.asInstanceOf[Numeric[Any]]
@@ -41,7 +41,7 @@ case object ByteType extends IntegralType {
 
   override val numeric: Numeric[Byte] = implicitly[Numeric[Byte]]
 
-  override val ordering: Ordering[Byte] = implicitly[Ordering[Byte]]
+  override val ordering: Option[Ordering[Byte]] = Some(implicitly[Ordering[Byte]])
 
   override def sql: String = "TINYINT"
 }
@@ -53,7 +53,7 @@ case object ShortType extends IntegralType {
 
   override val numeric: Numeric[Short] = implicitly[Numeric[Short]]
 
-  override val ordering: Ordering[Short] = implicitly[Ordering[Short]]
+  override val ordering: Option[Ordering[Short]] = Some(implicitly[Ordering[Short]])
 
   override def sql: String = "SMALLINT"
 }
@@ -65,7 +65,7 @@ case object IntType extends IntegralType {
 
   override val numeric: Numeric[Int] = implicitly[Numeric[Int]]
 
-  override val ordering: Ordering[Int] = implicitly[Ordering[Int]]
+  override val ordering: Option[Ordering[Int]] = Some(implicitly[Ordering[Int]])
 
   override def sql: String = "INT"
 }
@@ -77,7 +77,7 @@ case object LongType extends IntegralType {
 
   override val numeric: Numeric[Long] = implicitly[Numeric[Long]]
 
-  override val ordering: Ordering[Long] = implicitly[Ordering[Long]]
+  override val ordering: Option[Ordering[Long]] = Some(implicitly[Ordering[Long]])
 
   override def sql: String = "BIGINT"
 }
@@ -106,7 +106,7 @@ case object FloatType extends FractionalType {
 
   override val numeric: Numeric[Float] = implicitly[Numeric[Float]]
 
-  override val ordering: Ordering[Float] = implicitly[Ordering[Float]]
+  override val ordering: Option[Ordering[Float]] = Some(implicitly[Ordering[Float]])
 
   override def sql: String = "FLOAT"
 }
@@ -118,7 +118,7 @@ case object DoubleType extends FractionalType {
 
   override val numeric: Numeric[Double] = implicitly[Numeric[Double]]
 
-  override val ordering: Ordering[Double] = implicitly[Ordering[Double]]
+  override val ordering: Option[Ordering[Double]] = Some(implicitly[Ordering[Double]])
 
   override def sql: String = "DOUBLE"
 }

--- a/core/src/test/scala/scraper/types/DataTypeSuite.scala
+++ b/core/src/test/scala/scraper/types/DataTypeSuite.scala
@@ -150,4 +150,32 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
       testSchema.prettyTree
     )
   }
+
+  test("orderable ArrayType") {
+    val arrayType = ArrayType(IntType)
+    assert(arrayType subtypeOf OrderedType)
+  }
+
+  test("non-orderable ArrayType") {
+    val arrayType = ArrayType(MapType(IntType, StringType))
+    assert(!(arrayType subtypeOf OrderedType))
+  }
+
+  test("orderable StructType") {
+    val schema = StructType(
+      'f0 -> IntType.!,
+      'f1 -> DoubleType.!
+    )
+
+    assert(schema subtypeOf OrderedType)
+  }
+
+  test("non-orderable StructType") {
+    val schema = StructType(
+      'f0 -> IntType.!,
+      'f1 -> MapType(IntType, StringType)
+    )
+
+    assert(!(schema subtypeOf OrderedType))
+  }
 }

--- a/core/src/test/scala/scraper/types/DataTypeSuite.scala
+++ b/core/src/test/scala/scraper/types/DataTypeSuite.scala
@@ -153,12 +153,12 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
 
   test("orderable ArrayType") {
     val arrayType = ArrayType(IntType)
-    assert(arrayType subtypeOf OrderedType)
+    assert(arrayType isSubtypeOf OrderedType)
   }
 
   test("non-orderable ArrayType") {
     val arrayType = ArrayType(MapType(IntType, StringType))
-    assert(!(arrayType subtypeOf OrderedType))
+    assert(!(arrayType isSubtypeOf OrderedType))
   }
 
   test("orderable StructType") {
@@ -167,7 +167,7 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
       'f1 -> DoubleType.!
     )
 
-    assert(schema subtypeOf OrderedType)
+    assert(schema isSubtypeOf OrderedType)
   }
 
   test("non-orderable StructType") {
@@ -176,6 +176,6 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
       'f1 -> MapType(IntType, StringType)
     )
 
-    assert(!(schema subtypeOf OrderedType))
+    assert(!(schema isSubtypeOf OrderedType))
   }
 }


### PR DESCRIPTION
This PR tries to address issue #5 by adding ordering support for complex types. Before this PR, only primitive types extending from trait `OrderedType` are orderable. However, different instances of `ArrayType` and `StructType` may or may not be orderable:
- `ArrayType(elementType)` is orderable iff `elementType` is orderable
- `StructType(fields)` is orderable iff data types of all `fields` are orderable

Thus `OrderedType` doesn't make sense for `ArrayType` and `StructType`.

This PR made the following major changes:
1. Adds `DataType.genericOrdering: Option[Ordering[Any]]` to indicate whether a data type instance is orderable, and if it is, what's the specific ordering.
2. Trait `OrderedType` is removed, but object `OrderedType` is still there as an `AbstractDataType`, so that we can always check whether a specific data type instance is orderable using `OrderedType.isSupertypeOf`.

One known problem of this change is that "nulls first/last" semantics for `StructType` is not properly handled. Currently, ordering of all orderable `StructType` instances consider nulls are larger than non-null values.
