### PR TITLE
Simplifies TreeNode.prettyTree using annotation

### DIFF
--- a/core/src/main/java/scraper/annotations/Explain.java
+++ b/core/src/main/java/scraper/annotations/Explain.java
@@ -1,0 +1,14 @@
+package scraper.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER })
+public @interface Explain {
+  boolean hidden() default false;
+
+  boolean nestedTree() default false;
+}

--- a/core/src/main/scala/scraper/expressions/Expression.scala
+++ b/core/src/main/scala/scraper/expressions/Expression.scala
@@ -165,8 +165,6 @@ trait Expression extends TreeNode[Expression] with ExpressionDSL {
 
   lazy val childrenTypes: Seq[DataType] = children map (_.dataType)
 
-  override def nodeCaption: String = getClass.getSimpleName
-
   /**
    * A template method for building `debugString` and `sql`.
    */
@@ -271,6 +269,8 @@ trait BinaryExpression extends Expression {
 
 trait Operator { this: Expression =>
   def operator: String
+
+  override def nodeName: String = operator
 }
 
 trait BinaryOperator extends BinaryExpression with Operator {

--- a/core/src/main/scala/scraper/plans/physical/PhysicalPlan.scala
+++ b/core/src/main/scala/scraper/plans/physical/PhysicalPlan.scala
@@ -1,6 +1,7 @@
 package scraper.plans.physical
 
 import scraper._
+import scraper.annotations.Explain
 import scraper.expressions._
 import scraper.plans.QueryPlan
 
@@ -34,22 +35,12 @@ case object SingleRowRelation extends LeafPhysicalPlan {
 
 case class NotImplemented(
   logicalPlanName: String,
-  input: Seq[PhysicalPlan],
-  output: Seq[Attribute]
+  @Explain(hidden = true) input: Seq[PhysicalPlan],
+  @Explain(hidden = true) output: Seq[Attribute]
 ) extends PhysicalPlan {
   override def children: Seq[PhysicalPlan] = input
 
   override def iterator: Iterator[Row] = throw new UnsupportedOperationException(
     s"$logicalPlanName is not implemented yet"
   )
-
-  override protected def argValueStrings: Seq[Option[String]] = Seq(
-    Some(logicalPlanName), None, None
-  )
-
-  // The only expression nodes of `NotImplemented` are output attributes, which are not interesting
-  // to be shown in the query plan tree
-  override protected def buildNestedTree(
-    depth: Int, lastChildren: Seq[Boolean], builder: StringBuilder
-  ): Unit = ()
 }

--- a/execution/local/src/main/scala/scraper/local/plans/physical/basicOperators.scala
+++ b/execution/local/src/main/scala/scraper/local/plans/physical/basicOperators.scala
@@ -3,24 +3,18 @@ package scraper.local.plans.physical
 import scala.collection.mutable.ArrayBuffer
 
 import scraper._
+import scraper.annotations.Explain
 import scraper.expressions._
 import scraper.expressions.BoundRef.bind
 import scraper.expressions.Literal.True
 import scraper.plans.physical.{BinaryPhysicalPlan, LeafPhysicalPlan, PhysicalPlan, UnaryPhysicalPlan}
 
-case class LocalRelation(data: Iterable[Row], override val output: Seq[Attribute])
-  extends LeafPhysicalPlan {
+case class LocalRelation(
+  @Explain(hidden = true) data: Iterable[Row],
+  @Explain(hidden = true) override val output: Seq[Attribute]
+) extends LeafPhysicalPlan {
 
   override def iterator: Iterator[Row] = data.iterator
-
-  // Overrides this to avoid showing individual local data entry
-  override protected def argValueStrings: Seq[Option[String]] = Some("<local-data>") :: None :: Nil
-
-  // The only expression nodes of `LocalRelation` are output attributes, which are not interesting
-  // to be shown in the query plan tree
-  override protected def buildNestedTree(
-    depth: Int, lastChildren: Seq[Boolean], builder: StringBuilder
-  ): Unit = ()
 }
 
 case class Project(child: PhysicalPlan, projectList: Seq[NamedExpression])


### PR DESCRIPTION
This PR unifies and simplifies tree string generation for all concrete `TreeNode` types using a new Java annotation `@Explain`.

Currently, `@Explain` targets constructor parameters and has two properties:
- `hidden`
  
  When true, don't show this argument in `nodeCaption`. Defaults to `false`.
- `nestedTree`
  
  When true, show this argument as a nested tree of the current tree node. Can only be applied to constructor parameters whose type is also a `TreeNode[_]`. Defaults to `false`.
