### PR TITLE
Proper case sensitivity handling

### DIFF
--- a/core/src/main/scala/scraper/Catalog.scala
+++ b/core/src/main/scala/scraper/Catalog.scala
@@ -3,6 +3,7 @@ package scraper
 import scala.collection.mutable
 import scala.language.existentials
 
+import scraper.Name.caseInsensitive
 import scraper.exceptions.{FunctionNotFoundException, TableNotFoundException}
 import scraper.expressions._
 import scraper.plans.logical.LogicalPlan
@@ -27,7 +28,7 @@ class InMemoryCatalog extends Catalog {
       functions.getOrElse(name, throw new FunctionNotFoundException(name))
 
     override def registerFunction(fn: FunctionInfo): Unit =
-      functions(Name.ci(fn.name)) = fn
+      functions(caseInsensitive(fn.name)) = fn
 
     override def removeFunction(name: Name): Unit = functions -= name
   }

--- a/core/src/main/scala/scraper/Context.scala
+++ b/core/src/main/scala/scraper/Context.scala
@@ -50,9 +50,12 @@ trait Context {
 
   def q(query: String): DataFrame = new DataFrame(parse(query), this)
 
-  def table(name: String): DataFrame = new DataFrame(catalog lookupRelation name, this)
+  def table(name: Name): DataFrame =
+    new DataFrame(catalog lookupRelation name, this)
 
-  def table(name: Symbol): DataFrame = table(name.name)
+  def table(name: String): DataFrame = table(Name.cs(name))
+
+  def table(name: Symbol): DataFrame = table(Name.ci(name.name))
 
   def lift[T <: Product: WeakTypeTag](data: Iterable[T]): DataFrame =
     new DataFrame(LocalRelation(data), this)

--- a/core/src/main/scala/scraper/Context.scala
+++ b/core/src/main/scala/scraper/Context.scala
@@ -53,10 +53,6 @@ trait Context {
   def table(name: Name): DataFrame =
     new DataFrame(catalog lookupRelation name, this)
 
-  def table(name: String): DataFrame = table(Name.cs(name))
-
-  def table(name: Symbol): DataFrame = table(Name.ci(name.name))
-
   def lift[T <: Product: WeakTypeTag](data: Iterable[T]): DataFrame =
     new DataFrame(LocalRelation(data), this)
 

--- a/core/src/main/scala/scraper/DataFrame.scala
+++ b/core/src/main/scala/scraper/DataFrame.scala
@@ -125,7 +125,7 @@ class DataFrame(val queryExecution: QueryExecution) {
     val hasMoreData = truncated.length > rowCount
     val data = truncated take rowCount
 
-    val rows = schema.fields.map(_.name.casePreserving) +: data.map { row =>
+    val rows = schema.fields.map(_.name.toString) +: data.map { row =>
       row.map { cell =>
         val content = cell match {
           case null => "NULL"

--- a/core/src/main/scala/scraper/DataFrame.scala
+++ b/core/src/main/scala/scraper/DataFrame.scala
@@ -27,10 +27,6 @@ class DataFrame(val queryExecution: QueryExecution) {
       throw new ResolutionFailureException(s"Failed to resolve column name $column")
     }
 
-  def apply(column: String): Attribute = apply(Name.cs(column))
-
-  def apply(column: Symbol): Attribute = apply(Name.ci(column.name))
-
   def rename(newNames: String*): DataFrame = {
     assert(newNames.length == schema.fields.length)
     val oldNames = schema.fields map (_.name)
@@ -94,10 +90,6 @@ class DataFrame(val queryExecution: QueryExecution) {
 
   def asTable(tableName: Name): Unit =
     context.catalog.registerRelation(tableName, queryExecution.analyzedPlan)
-
-  def asTable(tableName: String): Unit = asTable(Name.cs(tableName))
-
-  def asTable(tableName: Symbol): Unit = asTable(Name.ci(tableName.name))
 
   def toSeq: Seq[Row] = iterator.toSeq
 

--- a/core/src/main/scala/scraper/FunctionRegistry.scala
+++ b/core/src/main/scala/scraper/FunctionRegistry.scala
@@ -25,7 +25,7 @@ object FunctionInfo {
 trait FunctionRegistry {
   def registerFunction(fn: FunctionInfo): Unit
 
-  def removeFunction(name: String): Unit
+  def removeFunction(name: Name): Unit
 
-  def lookupFunction(name: String): FunctionInfo
+  def lookupFunction(name: Name): FunctionInfo
 }

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -1,0 +1,48 @@
+package scraper
+
+trait Name {
+  def isCaseSensitive: Boolean
+
+  def casePreserving: String
+
+  def caseSensitive: Name
+
+  def caseInsensitive: Name
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Name if that.isCaseSensitive =>
+      that.casePreserving == this.casePreserving
+
+    case that: Name if !that.isCaseSensitive =>
+      that.casePreserving.compareToIgnoreCase(this.casePreserving) == 0
+
+    case _ =>
+      false
+  }
+
+  override def toString: String = casePreserving
+
+  override def hashCode(): Int = isCaseSensitive.hashCode() ^ casePreserving.hashCode
+}
+
+object Name {
+  def cs(name: String): Name = new CaseSensitiveName(name)
+
+  def ci(name: String): Name = new CaseInsensitiveName(name)
+}
+
+final class CaseSensitiveName(val casePreserving: String) extends Name {
+  override def isCaseSensitive: Boolean = true
+
+  override def caseSensitive: Name = this
+
+  override lazy val caseInsensitive: Name = new CaseInsensitiveName(casePreserving)
+}
+
+final class CaseInsensitiveName(val casePreserving: String) extends Name {
+  override def isCaseSensitive: Boolean = false
+
+  override lazy val caseSensitive: Name = new CaseSensitiveName(casePreserving)
+
+  override def caseInsensitive: Name = this
+}

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -9,20 +9,7 @@ trait Name {
 
   def caseInsensitive: Name
 
-  override def equals(other: Any): Boolean = other match {
-    case that: Name if that.isCaseSensitive =>
-      that.casePreserving == this.casePreserving
-
-    case that: Name if !that.isCaseSensitive =>
-      that.casePreserving.compareToIgnoreCase(this.casePreserving) == 0
-
-    case _ =>
-      false
-  }
-
   override def toString: String = casePreserving
-
-  override def hashCode(): Int = isCaseSensitive.hashCode() ^ casePreserving.hashCode
 }
 
 object Name {
@@ -37,6 +24,15 @@ final class CaseSensitiveName(val casePreserving: String) extends Name {
   override def caseSensitive: Name = this
 
   override lazy val caseInsensitive: Name = new CaseInsensitiveName(casePreserving)
+
+  override def toString: String = casePreserving
+
+  override def hashCode(): Int = casePreserving.hashCode
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Name => this.casePreserving == that.casePreserving
+    case _          => false
+  }
 }
 
 final class CaseInsensitiveName(val casePreserving: String) extends Name {
@@ -45,4 +41,19 @@ final class CaseInsensitiveName(val casePreserving: String) extends Name {
   override lazy val caseSensitive: Name = new CaseSensitiveName(casePreserving)
 
   override def caseInsensitive: Name = this
+
+  override def toString: String = casePreserving.toLowerCase
+
+  override def hashCode(): Int = casePreserving.hashCode
+
+  override def equals(other: Any): Boolean = other match {
+    case that: CaseInsensitiveName =>
+      this.casePreserving.compareToIgnoreCase(that.casePreserving) == 0
+
+    case that: CaseSensitiveName =>
+      this.casePreserving == that.casePreserving
+
+    case _ =>
+      false
+  }
 }

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -13,9 +13,9 @@ trait Name {
 }
 
 object Name {
-  def cs(name: String): CaseSensitiveName = new CaseSensitiveName(name)
+  def caseSensitive(name: String): CaseSensitiveName = new CaseSensitiveName(name)
 
-  def ci(name: String): CaseInsensitiveName = new CaseInsensitiveName(name)
+  def caseInsensitive(name: String): CaseInsensitiveName = new CaseInsensitiveName(name)
 }
 
 final class CaseSensitiveName(val casePreserving: String) extends Name {
@@ -44,7 +44,7 @@ final class CaseInsensitiveName(val casePreserving: String) extends Name {
 
   override def toString: String = casePreserving.toLowerCase
 
-  override def hashCode(): Int = casePreserving.hashCode
+  override def hashCode(): Int = casePreserving.toLowerCase.hashCode
 
   override def equals(other: Any): Boolean = other match {
     case that: CaseInsensitiveName =>

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -8,8 +8,7 @@ class Name(private val impl: Name.CaseSensitivityAware) {
   override def toString: String =
     if (isCaseSensitive) casePreserving else casePreserving.toLowerCase
 
-  override def hashCode(): Int =
-    if (isCaseSensitive) casePreserving.hashCode else casePreserving.toLowerCase.hashCode
+  override def hashCode(): Int = casePreserving.toLowerCase.hashCode
 
   override def equals(other: Any): Boolean = other match {
     case that: Name if this.isCaseSensitive || that.isCaseSensitive =>
@@ -37,6 +36,9 @@ object Name {
   private case class CaseInsensitive(casePreserving: String) extends CaseSensitivityAware {
     override def isCaseSensitive: Boolean = false
   }
+
+  def apply(name: String, isCaseSensitive: Boolean): Name =
+    if (isCaseSensitive) caseSensitive(name) else caseInsensitive(name)
 
   def caseSensitive(name: String): Name = new Name(CaseSensitive(name))
 

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -26,9 +26,9 @@ trait Name {
 }
 
 object Name {
-  def cs(name: String): Name = new CaseSensitiveName(name)
+  def cs(name: String): CaseSensitiveName = new CaseSensitiveName(name)
 
-  def ci(name: String): Name = new CaseInsensitiveName(name)
+  def ci(name: String): CaseInsensitiveName = new CaseInsensitiveName(name)
 }
 
 final class CaseSensitiveName(val casePreserving: String) extends Name {

--- a/core/src/main/scala/scraper/Name.scala
+++ b/core/src/main/scala/scraper/Name.scala
@@ -1,59 +1,44 @@
 package scraper
 
-trait Name {
-  def isCaseSensitive: Boolean
+class Name(private val impl: Name.CaseSensitivityAware) {
+  def isCaseSensitive: Boolean = impl.isCaseSensitive
 
-  def casePreserving: String
+  def casePreserving: String = impl.casePreserving
 
-  def caseSensitive: Name
+  override def toString: String =
+    if (isCaseSensitive) casePreserving else casePreserving.toLowerCase
 
-  def caseInsensitive: Name
-
-  override def toString: String = casePreserving
-}
-
-object Name {
-  def caseSensitive(name: String): CaseSensitiveName = new CaseSensitiveName(name)
-
-  def caseInsensitive(name: String): CaseInsensitiveName = new CaseInsensitiveName(name)
-}
-
-final class CaseSensitiveName(val casePreserving: String) extends Name {
-  override def isCaseSensitive: Boolean = true
-
-  override def caseSensitive: Name = this
-
-  override lazy val caseInsensitive: Name = new CaseInsensitiveName(casePreserving)
-
-  override def toString: String = casePreserving
-
-  override def hashCode(): Int = casePreserving.hashCode
+  override def hashCode(): Int =
+    if (isCaseSensitive) casePreserving.hashCode else casePreserving.toLowerCase.hashCode
 
   override def equals(other: Any): Boolean = other match {
-    case that: Name => this.casePreserving == that.casePreserving
-    case _          => false
-  }
-}
-
-final class CaseInsensitiveName(val casePreserving: String) extends Name {
-  override def isCaseSensitive: Boolean = false
-
-  override lazy val caseSensitive: Name = new CaseSensitiveName(casePreserving)
-
-  override def caseInsensitive: Name = this
-
-  override def toString: String = casePreserving.toLowerCase
-
-  override def hashCode(): Int = casePreserving.toLowerCase.hashCode
-
-  override def equals(other: Any): Boolean = other match {
-    case that: CaseInsensitiveName =>
-      this.casePreserving.compareToIgnoreCase(that.casePreserving) == 0
-
-    case that: CaseSensitiveName =>
+    case that: Name if this.isCaseSensitive || that.isCaseSensitive =>
       this.casePreserving == that.casePreserving
+
+    case that: Name =>
+      this.casePreserving.compareToIgnoreCase(that.casePreserving) == 0
 
     case _ =>
       false
   }
+}
+
+object Name {
+  private trait CaseSensitivityAware {
+    def isCaseSensitive: Boolean
+
+    def casePreserving: String
+  }
+
+  private case class CaseSensitive(casePreserving: String) extends CaseSensitivityAware {
+    override def isCaseSensitive: Boolean = true
+  }
+
+  private case class CaseInsensitive(casePreserving: String) extends CaseSensitivityAware {
+    override def isCaseSensitive: Boolean = false
+  }
+
+  def caseSensitive(name: String): Name = new Name(CaseSensitive(name))
+
+  def caseInsensitive(name: String): Name = new Name(CaseInsensitive(name))
 }

--- a/core/src/main/scala/scraper/exceptions/exceptions.scala
+++ b/core/src/main/scala/scraper/exceptions/exceptions.scala
@@ -1,5 +1,6 @@
 package scraper.exceptions
 
+import scraper.Name
 import scraper.expressions.{AttributeRef, Expression}
 import scraper.plans.logical.LogicalPlan
 import scraper.types.{AbstractDataType, DataType}
@@ -117,16 +118,16 @@ class ResolutionFailureException(message: String, cause: Throwable)
   def this(message: String) = this(message, null)
 }
 
-class TableNotFoundException(tableName: String, cause: Throwable)
+class TableNotFoundException(tableName: Name, cause: Throwable)
   extends AnalysisException(s"Table $tableName not found", cause) {
 
-  def this(tableName: String) = this(tableName, null)
+  def this(tableName: Name) = this(tableName, null)
 }
 
-class FunctionNotFoundException(name: String, cause: Throwable)
+class FunctionNotFoundException(name: Name, cause: Throwable)
   extends AnalysisException(s"Function $name not found", cause) {
 
-  def this(name: String) = this(name, null)
+  def this(name: Name) = this(name, null)
 }
 
 class SchemaIncompatibleException(message: String, cause: Throwable)

--- a/core/src/main/scala/scraper/expressions/Expression.scala
+++ b/core/src/main/scala/scraper/expressions/Expression.scala
@@ -2,7 +2,7 @@ package scraper.expressions
 
 import scala.util.{Failure, Try}
 
-import scraper.Row
+import scraper.{Name, Row}
 import scraper.exceptions._
 import scraper.expressions.dsl.ExpressionDSL
 import scraper.expressions.typecheck.{PassThrough, TypeConstraint}
@@ -305,7 +305,7 @@ trait UnresolvedExpression extends Expression with UnevaluableExpression with No
   ))
 }
 
-case class UnresolvedFunction(name: String, args: Seq[Expression], distinct: Boolean)
+case class UnresolvedFunction(name: Name, args: Seq[Expression], distinct: Boolean)
   extends UnresolvedExpression {
 
   override def children: Seq[Expression] = args

--- a/core/src/main/scala/scraper/expressions/dsl/ExpressionDSL.scala
+++ b/core/src/main/scala/scraper/expressions/dsl/ExpressionDSL.scala
@@ -14,10 +14,6 @@ trait ExpressionDSL
 
   def as(alias: Name): Alias = Alias(this, alias, newExpressionID())
 
-  def as(alias: String): Alias = as(Name.cs(alias))
-
-  def as(alias: Symbol): Alias = as(Name.ci(alias.name))
-
   def cast(dataType: DataType): Cast = Cast(this, dataType)
 
   def isNull: IsNull = IsNull(this)

--- a/core/src/main/scala/scraper/expressions/dsl/ExpressionDSL.scala
+++ b/core/src/main/scala/scraper/expressions/dsl/ExpressionDSL.scala
@@ -2,6 +2,7 @@ package scraper.expressions.dsl
 
 import scala.language.implicitConversions
 
+import scraper.Name
 import scraper.expressions._
 import scraper.expressions.NamedExpression.newExpressionID
 import scraper.types.DataType
@@ -11,9 +12,11 @@ trait ExpressionDSL
   with ComparisonDSL
   with LogicalOperatorDSL { this: Expression =>
 
-  def as(alias: String): Alias = Alias(this, alias, newExpressionID())
+  def as(alias: Name): Alias = Alias(this, alias, newExpressionID())
 
-  def as(alias: Symbol): Alias = Alias(this, alias.name, newExpressionID())
+  def as(alias: String): Alias = as(Name.cs(alias))
+
+  def as(alias: Symbol): Alias = as(Name.ci(alias.name))
 
   def cast(dataType: DataType): Cast = Cast(this, dataType)
 

--- a/core/src/main/scala/scraper/expressions/dsl/package.scala
+++ b/core/src/main/scala/scraper/expressions/dsl/package.scala
@@ -26,7 +26,7 @@ package object dsl {
   implicit def `String->Literal`(value: String): Literal = Literal(value, StringType)
 
   implicit def `Symbol->UnresolvedAttribute`(name: Symbol): UnresolvedAttribute =
-    UnresolvedAttribute(Name.ci(name.name))
+    UnresolvedAttribute(name)
 
   implicit def `Name->UnresolvedAttribute`(name: Name): UnresolvedAttribute =
     UnresolvedAttribute(name)
@@ -79,20 +79,8 @@ package object dsl {
   def function(name: Name, args: Expression*): UnresolvedFunction =
     UnresolvedFunction(name, args, distinct = false)
 
-  def function(name: String, args: Expression*): UnresolvedFunction =
-    function(Name.cs(name), args: _*)
-
-  def function(name: Symbol, args: Expression*): UnresolvedFunction =
-    function(Name.ci(name.name), args: _*)
-
   def distinctFunction(name: Name, args: Expression*): UnresolvedFunction =
     UnresolvedFunction(name, args, distinct = true)
-
-  def distinctFunction(name: String, args: Expression*): UnresolvedFunction =
-    distinctFunction(Name.cs(name), args: _*)
-
-  def distinctFunction(name: Symbol, args: Expression*): UnresolvedFunction =
-    distinctFunction(Name.ci(name.name), args: _*)
 
   private[scraper] implicit class TypeConstraintDSL(input: Seq[Expression]) {
     def sameTypeAs(dataType: DataType): SameTypeAs = SameTypeAs(dataType, input)

--- a/core/src/main/scala/scraper/expressions/dsl/package.scala
+++ b/core/src/main/scala/scraper/expressions/dsl/package.scala
@@ -2,6 +2,7 @@ package scraper.expressions
 
 import scala.language.implicitConversions
 
+import scraper.Name
 import scraper.config.Settings
 import scraper.expressions.typecheck._
 import scraper.parser.Parser
@@ -25,7 +26,10 @@ package object dsl {
   implicit def `String->Literal`(value: String): Literal = Literal(value, StringType)
 
   implicit def `Symbol->UnresolvedAttribute`(name: Symbol): UnresolvedAttribute =
-    UnresolvedAttribute(name.name)
+    UnresolvedAttribute(Name.ci(name.name))
+
+  implicit def `Name->UnresolvedAttribute`(name: Name): UnresolvedAttribute =
+    UnresolvedAttribute(name)
 
   implicit class StringToUnresolvedAttribute(sc: StringContext) {
     def $(args: Any*): UnresolvedAttribute =
@@ -72,16 +76,23 @@ package object dsl {
     }
   }
 
-  def function(name: String, args: Expression*): UnresolvedFunction =
+  def function(name: Name, args: Expression*): UnresolvedFunction =
     UnresolvedFunction(name, args, distinct = false)
 
-  def function(name: Symbol, args: Expression*): UnresolvedFunction = function(name.name, args: _*)
+  def function(name: String, args: Expression*): UnresolvedFunction =
+    function(Name.cs(name), args: _*)
 
-  def distinctFunction(name: String, args: Expression*): UnresolvedFunction =
+  def function(name: Symbol, args: Expression*): UnresolvedFunction =
+    function(Name.ci(name.name), args: _*)
+
+  def distinctFunction(name: Name, args: Expression*): UnresolvedFunction =
     UnresolvedFunction(name, args, distinct = true)
 
+  def distinctFunction(name: String, args: Expression*): UnresolvedFunction =
+    distinctFunction(Name.cs(name), args: _*)
+
   def distinctFunction(name: Symbol, args: Expression*): UnresolvedFunction =
-    distinctFunction(name.name, args: _*)
+    distinctFunction(Name.ci(name.name), args: _*)
 
   private[scraper] implicit class TypeConstraintDSL(input: Seq[Expression]) {
     def sameTypeAs(dataType: DataType): SameTypeAs = SameTypeAs(dataType, input)

--- a/core/src/main/scala/scraper/expressions/generatedNamed.scala
+++ b/core/src/main/scala/scraper/expressions/generatedNamed.scala
@@ -37,7 +37,7 @@ object GeneratedNamedExpression {
 
 trait GeneratedAlias extends GeneratedNamedExpression with UnaryExpression {
   override def debugString: String =
-    s"(${child.debugString} AS g:${quote(name.casePreserving)}#${expressionID.id})"
+    s"(${child.debugString} AS g:${quote(name.toString)}#${expressionID.id})"
 
   override def dataType: DataType = child.dataType
 

--- a/core/src/main/scala/scraper/expressions/generatedNamed.scala
+++ b/core/src/main/scala/scraper/expressions/generatedNamed.scala
@@ -1,7 +1,6 @@
 package scraper.expressions
 
 import scraper.Name
-import scraper.Name.ci
 import scraper.expressions.GeneratedNamedExpression.{ForAggregation, ForGrouping, Purpose}
 import scraper.expressions.NamedExpression.newExpressionID
 import scraper.types._
@@ -25,14 +24,14 @@ object GeneratedNamedExpression {
    * Marks [[GeneratedNamedExpression]]s that are used to wrap/reference grouping expressions.
    */
   case object ForGrouping extends Purpose {
-    override def name: Name = ci("group")
+    override def name: Name = 'group
   }
 
   /**
    * Marks [[GeneratedNamedExpression]]s that are used to wrap/reference aggregate functions.
    */
   case object ForAggregation extends Purpose {
-    override def name: Name = ci("agg")
+    override def name: Name = 'agg
   }
 }
 

--- a/core/src/main/scala/scraper/expressions/generatedNamed.scala
+++ b/core/src/main/scala/scraper/expressions/generatedNamed.scala
@@ -1,5 +1,7 @@
 package scraper.expressions
 
+import scraper.Name
+import scraper.Name.ci
 import scraper.expressions.GeneratedNamedExpression.{ForAggregation, ForGrouping, Purpose}
 import scraper.expressions.NamedExpression.newExpressionID
 import scraper.types._
@@ -8,7 +10,7 @@ import scraper.utils._
 sealed trait GeneratedNamedExpression extends NamedExpression {
   def purpose: Purpose
 
-  override def name: String = purpose.name
+  override def name: Name = purpose.name
 }
 
 object GeneratedNamedExpression {
@@ -16,27 +18,27 @@ object GeneratedNamedExpression {
    * Indicates the purpose of a [[GeneratedNamedExpression]].
    */
   sealed trait Purpose {
-    def name: String
+    def name: Name
   }
 
   /**
    * Marks [[GeneratedNamedExpression]]s that are used to wrap/reference grouping expressions.
    */
   case object ForGrouping extends Purpose {
-    override def name: String = "group"
+    override def name: Name = ci("group")
   }
 
   /**
    * Marks [[GeneratedNamedExpression]]s that are used to wrap/reference aggregate functions.
    */
   case object ForAggregation extends Purpose {
-    override def name: String = "agg"
+    override def name: Name = ci("agg")
   }
 }
 
 trait GeneratedAlias extends GeneratedNamedExpression with UnaryExpression {
   override def debugString: String =
-    s"(${child.debugString} AS g:${quote(name)}#${expressionID.id})"
+    s"(${child.debugString} AS g:${quote(name.casePreserving)}#${expressionID.id})"
 
   override def dataType: DataType = child.dataType
 

--- a/core/src/main/scala/scraper/expressions/named.scala
+++ b/core/src/main/scala/scraper/expressions/named.scala
@@ -129,7 +129,7 @@ case class AutoAlias private (child: Expression)
 }
 
 object AutoAlias {
-  val AnonymousColumnName = "?column?"
+  val AnonymousColumnName: String = "?column?"
 
   def named(child: Expression): NamedExpression = child match {
     case e: NamedExpression => e
@@ -164,10 +164,6 @@ case class UnresolvedAttribute(name: Name, qualifier: Option[Name] = None)
   def qualifiedBy(qualifier: Option[Name]): UnresolvedAttribute = copy(qualifier = qualifier)
 
   def of(qualifier: Name): UnresolvedAttribute = qualifiedBy(Some(qualifier))
-
-  def of(qualifier: String): UnresolvedAttribute = of(Name.ci(qualifier))
-
-  def of(qualifier: Symbol): UnresolvedAttribute = of(qualifier.name)
 
   def of(dataType: DataType): AttributeRef =
     AttributeRef(name, dataType, isNullable = true, newExpressionID())
@@ -240,16 +236,6 @@ case class AttributeRef(
    * Returns a copy of this [[AttributeRef]] with given qualifier.
    */
   def of(qualifier: Name): AttributeRef = qualifiedBy(Some(qualifier))
-
-  /**
-   * Returns a copy of this [[AttributeRef]] with given qualifier.
-   */
-  def of(qualifier: String): AttributeRef = of(Name.ci(qualifier))
-
-  /**
-   * Returns a copy of this [[AttributeRef]] with given qualifier.
-   */
-  def of(qualifier: Symbol): AttributeRef = of(qualifier.name)
 }
 
 case class BoundRef(ordinal: Int, override val dataType: DataType, override val isNullable: Boolean)

--- a/core/src/main/scala/scraper/expressions/named.scala
+++ b/core/src/main/scala/scraper/expressions/named.scala
@@ -48,7 +48,7 @@ object NamedExpression {
 
     override lazy val isNullable: Boolean = named.isNullable
 
-    override def sql: Try[String] = Try(named.name.casePreserving)
+    override def sql: Try[String] = Try(named.name.toString)
   }
 
   object UnquotedName {
@@ -63,7 +63,7 @@ case class Star(qualifier: Option[Name]) extends LeafExpression with UnresolvedN
   override def toAttribute: Attribute = throw new ExpressionUnresolvedException(this)
 
   override protected def template: String =
-    (qualifier map (_.casePreserving) map quote).toSeq :+ "*" mkString "."
+    (qualifier map (_.toString) map quote).toSeq :+ "*" mkString "."
 }
 
 case class Alias(
@@ -84,10 +84,10 @@ case class Alias(
   }
 
   override def debugString: String =
-    s"(${child.debugString} AS ${quote(name.casePreserving)}#${expressionID.id})"
+    s"(${child.debugString} AS ${quote(name.toString)}#${expressionID.id})"
 
   override def sql: Try[String] =
-    child.sql map (childSQL => s"$childSQL AS ${quote(name.casePreserving)}")
+    child.sql map (childSQL => s"$childSQL AS ${quote(name.toString)}")
 
   def withID(id: ExpressionID): Alias = copy(expressionID = id)
 }
@@ -157,7 +157,7 @@ case class UnresolvedAttribute(name: Name, qualifier: Option[Name] = None)
   extends Attribute with UnresolvedNamedExpression {
 
   override protected def template: String =
-    (qualifier.map(_.casePreserving).toSeq :+ name.casePreserving) map quote mkString "."
+    (qualifier.map(_.toString).toSeq :+ name.toString) map quote mkString "."
 
   override def withID(id: ExpressionID): Attribute = this
 
@@ -188,10 +188,10 @@ case class UnresolvedAttribute(name: Name, qualifier: Option[Name] = None)
 trait ResolvedAttribute extends Attribute {
   override def debugString: String = {
     val nullability = if (isNullable) "?" else "!"
-    s"${quote(name.casePreserving)}:${dataType.sql}$nullability#${expressionID.id}"
+    s"${quote(name.toString)}:${dataType.sql}$nullability#${expressionID.id}"
   }
 
-  override def sql: Try[String] = Success(s"${quote(name.casePreserving)}")
+  override def sql: Try[String] = Success(s"${quote(name.toString)}")
 
   def at(ordinal: Int): BoundRef = BoundRef(ordinal, dataType, isNullable)
 }
@@ -225,7 +225,7 @@ case class AttributeRef(
   override def withNullability(nullable: Boolean): AttributeRef = copy(isNullable = nullable)
 
   override def debugString: String =
-    ((qualifier.map(_.casePreserving).toSeq map quote) :+ super.debugString) mkString "."
+    ((qualifier.map(_.toString).toSeq map quote) :+ super.debugString) mkString "."
 
   /**
    * Returns a copy of this [[AttributeRef]] with given qualifier.

--- a/core/src/main/scala/scraper/expressions/named.scala
+++ b/core/src/main/scala/scraper/expressions/named.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.util.{Success, Try}
 
 import scraper.{Name, Row}
+import scraper.Name.caseInsensitive
 import scraper.exceptions.{ExpressionUnresolvedException, ResolutionFailureException}
 import scraper.expressions.NamedExpression.newExpressionID
 import scraper.expressions.functions._
@@ -241,7 +242,7 @@ case class AttributeRef(
 case class BoundRef(ordinal: Int, override val dataType: DataType, override val isNullable: Boolean)
   extends NamedExpression with LeafExpression with NonSQLExpression {
 
-  override val name: Name = Name.ci(s"input[$ordinal]")
+  override val name: Name = caseInsensitive(s"input[$ordinal]")
 
   override def toAttribute: Attribute = throw new UnsupportedOperationException
 

--- a/core/src/main/scala/scraper/expressions/named.scala
+++ b/core/src/main/scala/scraper/expressions/named.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.util.{Success, Try}
 
-import scraper.Row
+import scraper.{Name, Row}
 import scraper.exceptions.{ExpressionUnresolvedException, ResolutionFailureException}
 import scraper.expressions.NamedExpression.newExpressionID
 import scraper.expressions.functions._
@@ -14,7 +14,7 @@ import scraper.utils._
 case class ExpressionID(id: Long)
 
 trait NamedExpression extends Expression {
-  def name: String
+  def name: Name
 
   def expressionID: ExpressionID
 
@@ -32,7 +32,7 @@ object NamedExpression {
 
   def newExpressionID(): ExpressionID = ExpressionID(currentID.getAndIncrement())
 
-  def unapply(e: NamedExpression): Option[(String, DataType)] = Some((e.name, e.dataType))
+  def unapply(e: NamedExpression): Option[(Name, DataType)] = Some((e.name, e.dataType))
 
   /**
    * Auxiliary class only used for removing back-ticks and double-quotes from auto-generated column
@@ -48,7 +48,7 @@ object NamedExpression {
 
     override lazy val isNullable: Boolean = named.isNullable
 
-    override def sql: Try[String] = Try(named.name)
+    override def sql: Try[String] = Try(named.name.casePreserving)
   }
 
   object UnquotedName {
@@ -57,17 +57,18 @@ object NamedExpression {
   }
 }
 
-case class Star(qualifier: Option[String]) extends LeafExpression with UnresolvedNamedExpression {
-  override def name: String = throw new ExpressionUnresolvedException(this)
+case class Star(qualifier: Option[Name]) extends LeafExpression with UnresolvedNamedExpression {
+  override def name: Name = throw new ExpressionUnresolvedException(this)
 
   override def toAttribute: Attribute = throw new ExpressionUnresolvedException(this)
 
-  override protected def template: String = (qualifier map quote).toSeq :+ "*" mkString "."
+  override protected def template: String =
+    (qualifier map (_.casePreserving) map quote).toSeq :+ "*" mkString "."
 }
 
 case class Alias(
   child: Expression,
-  name: String,
+  name: Name,
   override val expressionID: ExpressionID
 ) extends NamedExpression with UnaryExpression {
   override lazy val isFoldable: Boolean = false
@@ -82,9 +83,11 @@ case class Alias(
     UnresolvedAttribute(name)
   }
 
-  override def debugString: String = s"(${child.debugString} AS ${quote(name)}#${expressionID.id})"
+  override def debugString: String =
+    s"(${child.debugString} AS ${quote(name.casePreserving)}#${expressionID.id})"
 
-  override def sql: Try[String] = child.sql map (childSQL => s"$childSQL AS ${quote(name)}")
+  override def sql: Try[String] =
+    child.sql map (childSQL => s"$childSQL AS ${quote(name.casePreserving)}")
 
   def withID(id: ExpressionID): Alias = copy(expressionID = id)
 }
@@ -118,7 +121,7 @@ case class AutoAlias private (child: Expression)
   with UnresolvedNamedExpression
   with UnevaluableExpression {
 
-  override def name: String = throw new ExpressionUnresolvedException(this)
+  override def name: Name = throw new ExpressionUnresolvedException(this)
 
   override def toAttribute: Attribute = throw new ExpressionUnresolvedException(this)
 
@@ -150,16 +153,19 @@ trait Attribute extends NamedExpression with LeafExpression {
   def ! : Attribute = withNullability(false)
 }
 
-case class UnresolvedAttribute(name: String, qualifier: Option[String] = None)
+case class UnresolvedAttribute(name: Name, qualifier: Option[Name] = None)
   extends Attribute with UnresolvedNamedExpression {
 
-  override protected def template: String = (qualifier.toSeq :+ name) map quote mkString "."
+  override protected def template: String =
+    (qualifier.map(_.casePreserving).toSeq :+ name.casePreserving) map quote mkString "."
 
   override def withID(id: ExpressionID): Attribute = this
 
-  def qualifiedBy(qualifier: Option[String]): UnresolvedAttribute = copy(qualifier = qualifier)
+  def qualifiedBy(qualifier: Option[Name]): UnresolvedAttribute = copy(qualifier = qualifier)
 
-  def of(qualifier: String): UnresolvedAttribute = qualifiedBy(Some(qualifier))
+  def of(qualifier: Name): UnresolvedAttribute = qualifiedBy(Some(qualifier))
+
+  def of(qualifier: String): UnresolvedAttribute = of(Name.ci(qualifier))
 
   def of(qualifier: Symbol): UnresolvedAttribute = of(qualifier.name)
 
@@ -186,20 +192,20 @@ case class UnresolvedAttribute(name: String, qualifier: Option[String] = None)
 trait ResolvedAttribute extends Attribute {
   override def debugString: String = {
     val nullability = if (isNullable) "?" else "!"
-    s"${quote(name)}:${dataType.sql}$nullability#${expressionID.id}"
+    s"${quote(name.casePreserving)}:${dataType.sql}$nullability#${expressionID.id}"
   }
 
-  override def sql: Try[String] = Success(s"${quote(name)}")
+  override def sql: Try[String] = Success(s"${quote(name.casePreserving)}")
 
   def at(ordinal: Int): BoundRef = BoundRef(ordinal, dataType, isNullable)
 }
 
 case class AttributeRef(
-  name: String,
+  name: Name,
   override val dataType: DataType,
   override val isNullable: Boolean,
   override val expressionID: ExpressionID,
-  qualifier: Option[String] = None
+  qualifier: Option[Name] = None
 ) extends ResolvedAttribute with UnevaluableExpression {
 
   /**
@@ -222,17 +228,23 @@ case class AttributeRef(
    */
   override def withNullability(nullable: Boolean): AttributeRef = copy(isNullable = nullable)
 
-  override def debugString: String = ((qualifier.toSeq map quote) :+ super.debugString) mkString "."
+  override def debugString: String =
+    ((qualifier.map(_.casePreserving).toSeq map quote) :+ super.debugString) mkString "."
 
   /**
    * Returns a copy of this [[AttributeRef]] with given qualifier.
    */
-  def qualifiedBy(qualifier: Option[String]): AttributeRef = copy(qualifier = qualifier)
+  def qualifiedBy(qualifier: Option[Name]): AttributeRef = copy(qualifier = qualifier)
 
   /**
    * Returns a copy of this [[AttributeRef]] with given qualifier.
    */
-  def of(qualifier: String): AttributeRef = qualifiedBy(Some(qualifier))
+  def of(qualifier: Name): AttributeRef = qualifiedBy(Some(qualifier))
+
+  /**
+   * Returns a copy of this [[AttributeRef]] with given qualifier.
+   */
+  def of(qualifier: String): AttributeRef = of(Name.ci(qualifier))
 
   /**
    * Returns a copy of this [[AttributeRef]] with given qualifier.
@@ -243,7 +255,7 @@ case class AttributeRef(
 case class BoundRef(ordinal: Int, override val dataType: DataType, override val isNullable: Boolean)
   extends NamedExpression with LeafExpression with NonSQLExpression {
 
-  override val name: String = s"input[$ordinal]"
+  override val name: Name = Name.ci(s"input[$ordinal]")
 
   override def toAttribute: Attribute = throw new UnsupportedOperationException
 

--- a/core/src/main/scala/scraper/package.scala
+++ b/core/src/main/scala/scraper/package.scala
@@ -6,4 +6,12 @@ package object scraper {
 
   implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): CaseInsensitiveName =
     Name.ci(symbol.name)
+
+  implicit class StringToCaseSensitiveName(sc: StringContext) {
+    def cs(args: Any*): CaseSensitiveName = Name.cs(sc.s(args: _*))
+  }
+
+  implicit class StringToCaseInsensitiveName(sc: StringContext) {
+    def ci(args: Any*): CaseInsensitiveName = Name.ci(sc.s(args: _*))
+  }
 }

--- a/core/src/main/scala/scraper/package.scala
+++ b/core/src/main/scala/scraper/package.scala
@@ -1,0 +1,9 @@
+import scala.language.implicitConversions
+
+package object scraper {
+  implicit def `String->CaseSensitiveName`(string: String): CaseSensitiveName =
+    Name.cs(string)
+
+  implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): CaseInsensitiveName =
+    Name.ci(symbol.name)
+}

--- a/core/src/main/scala/scraper/package.scala
+++ b/core/src/main/scala/scraper/package.scala
@@ -2,16 +2,16 @@ import scala.language.implicitConversions
 
 package object scraper {
   implicit def `String->CaseSensitiveName`(string: String): CaseSensitiveName =
-    Name.cs(string)
+    Name.caseSensitive(string)
 
   implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): CaseInsensitiveName =
-    Name.ci(symbol.name)
+    Name.caseInsensitive(symbol.name)
 
   implicit class StringToCaseSensitiveName(sc: StringContext) {
-    def cs(args: Any*): CaseSensitiveName = Name.cs(sc.s(args: _*))
+    def cs(args: Any*): CaseSensitiveName = Name.caseSensitive(sc.s(args: _*))
   }
 
   implicit class StringToCaseInsensitiveName(sc: StringContext) {
-    def ci(args: Any*): CaseInsensitiveName = Name.ci(sc.s(args: _*))
+    def ci(args: Any*): CaseInsensitiveName = Name.caseInsensitive(sc.s(args: _*))
   }
 }

--- a/core/src/main/scala/scraper/package.scala
+++ b/core/src/main/scala/scraper/package.scala
@@ -1,17 +1,15 @@
 import scala.language.implicitConversions
 
+import scraper.Name.{caseInsensitive, caseSensitive}
+
 package object scraper {
-  implicit def `String->CaseSensitiveName`(string: String): Name =
-    Name.caseSensitive(string)
+  implicit def `String->CaseSensitiveName`(string: String): Name = caseSensitive(string)
 
-  implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): Name =
-    Name.caseInsensitive(symbol.name)
+  implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): Name = caseInsensitive(symbol.name)
 
-  implicit class StringToCaseSensitiveName(sc: StringContext) {
-    def cs(args: Any*): Name = Name.caseSensitive(sc.s(args: _*))
-  }
+  implicit class NameHelper(sc: StringContext) {
+    def cs(args: Any*): Name = caseSensitive(sc.s(args: _*))
 
-  implicit class StringToCaseInsensitiveName(sc: StringContext) {
-    def ci(args: Any*): Name = Name.caseInsensitive(sc.s(args: _*))
+    def ci(args: Any*): Name = caseInsensitive(sc.s(args: _*))
   }
 }

--- a/core/src/main/scala/scraper/package.scala
+++ b/core/src/main/scala/scraper/package.scala
@@ -1,17 +1,17 @@
 import scala.language.implicitConversions
 
 package object scraper {
-  implicit def `String->CaseSensitiveName`(string: String): CaseSensitiveName =
+  implicit def `String->CaseSensitiveName`(string: String): Name =
     Name.caseSensitive(string)
 
-  implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): CaseInsensitiveName =
+  implicit def `Symbol->CaseInsensitiveName`(symbol: Symbol): Name =
     Name.caseInsensitive(symbol.name)
 
   implicit class StringToCaseSensitiveName(sc: StringContext) {
-    def cs(args: Any*): CaseSensitiveName = Name.caseSensitive(sc.s(args: _*))
+    def cs(args: Any*): Name = Name.caseSensitive(sc.s(args: _*))
   }
 
   implicit class StringToCaseInsensitiveName(sc: StringContext) {
-    def ci(args: Any*): CaseInsensitiveName = Name.caseInsensitive(sc.s(args: _*))
+    def ci(args: Any*): Name = Name.caseInsensitive(sc.s(args: _*))
   }
 }

--- a/core/src/main/scala/scraper/parser/Parser.scala
+++ b/core/src/main/scala/scraper/parser/Parser.scala
@@ -77,7 +77,7 @@ abstract class TokenParser[T] extends StdTokenParsers {
 class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
   def parseAttribute(input: String): UnresolvedAttribute = synchronized {
     val start = attribute | star ^^ {
-      case Star(qualifier) => UnresolvedAttribute(cs("*"), qualifier)
+      case Star(qualifier) => UnresolvedAttribute("*", qualifier)
     }
 
     phrase(start)(new lexical.Scanner(input)) match {

--- a/core/src/main/scala/scraper/parser/Parser.scala
+++ b/core/src/main/scala/scraper/parser/Parser.scala
@@ -7,6 +7,8 @@ import scala.util.parsing.combinator.syntactical.StdTokenParsers
 import scala.util.parsing.combinator.token.StdTokens
 import scala.util.parsing.input.CharArrayReader.EofCh
 
+import scraper.Name
+import scraper.Name.{ci, cs}
 import scraper.config.Settings
 import scraper.exceptions.ParsingException
 import scraper.expressions._
@@ -20,12 +22,42 @@ trait Tokens extends StdTokens {
   case class FloatLit(chars: String) extends Token {
     override def toString: String = chars
   }
+
+  case class UnquotedIdentifier(chars: String) extends Token {
+    override def toString: String = chars
+  }
+
+  case class QuotedIdentifier(chars: String) extends Token {
+    override def toString: String = chars
+  }
 }
 
 abstract class TokenParser[T] extends StdTokenParsers {
   override type Tokens = Lexical
 
-  private val keywords = mutable.Set.empty[String]
+  import lexical.{FloatLit, QuotedIdentifier, UnquotedIdentifier}
+
+  override lazy val lexical: Tokens = new Lexical(keywords.toSet)
+
+  def parse(input: String): T = synchronized {
+    phrase(start)(new lexical.Scanner(input)) match {
+      case Success(plan, _) => plan
+      case failureOrError   => throw new ParsingException(failureOrError.toString)
+    }
+  }
+
+  def floatLit: Parser[String] =
+    elem("float", _.isInstanceOf[FloatLit]) ^^ (_.chars)
+
+  def quotedIdent: Parser[Name] =
+    elem("quoted identifier", _.isInstanceOf[QuotedIdentifier]) ^^ {
+      token => cs(token.chars)
+    }
+
+  def unquotedIdent: Parser[Name] =
+    elem("unquoted identifier", _.isInstanceOf[UnquotedIdentifier]) ^^ {
+      token => ci(token.chars)
+    }
 
   protected case class Keyword(name: String) {
     keywords += normalized
@@ -35,24 +67,17 @@ abstract class TokenParser[T] extends StdTokenParsers {
     def asParser: Parser[String] = normalized
   }
 
-  override lazy val lexical: Tokens = new Lexical(keywords.toSet)
+  protected def start: Parser[T]
 
   protected implicit def `Keyword->Parser[String]`(k: Keyword): Parser[String] = k.asParser
 
-  def parse(input: String): T = synchronized {
-    phrase(start)(new lexical.Scanner(input)) match {
-      case Success(plan, _) => plan
-      case failureOrError   => throw new ParsingException(failureOrError.toString)
-    }
-  }
-
-  protected def start: Parser[T]
+  private val keywords = mutable.Set.empty[String]
 }
 
 class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
   def parseAttribute(input: String): UnresolvedAttribute = synchronized {
     val start = attribute | star ^^ {
-      case Star(qualifier) => UnresolvedAttribute("*", qualifier)
+      case Star(qualifier) => UnresolvedAttribute(cs("*"), qualifier)
     }
 
     phrase(start)(new lexical.Scanner(input)) match {
@@ -60,6 +85,9 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
       case failureOrError => throw new ParsingException(failureOrError.toString)
     }
   }
+
+  override protected def start: Parser[LogicalPlan] =
+    query
 
   private val ALL = Keyword("ALL")
   private val AND = Keyword("AND")
@@ -115,9 +143,6 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
   private val WHERE = Keyword("WHERE")
   private val WITH = Keyword("WITH")
 
-  override protected def start: Parser[LogicalPlan] =
-    query
-
   private def query: Parser[LogicalPlan] =
     ctes.? ~ queryNoWith ^^ {
       case cs ~ q =>
@@ -126,13 +151,15 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
         }) getOrElse q
     }
 
-  private def ctes: Parser[Seq[(String, LogicalPlan)]] =
+  private def ctes: Parser[Seq[(Name, LogicalPlan)]] =
     WITH ~> rep1sep(namedQuery, ",")
 
-  private def namedQuery: Parser[(String, LogicalPlan)] =
-    ident ~ (AS.? ~ "(" ~> queryNoWith <~ ")") ^^ {
+  private def namedQuery: Parser[(Name, LogicalPlan)] =
+    identifier ~ (AS.? ~ "(" ~> queryNoWith <~ ")") ^^ {
       case name ~ plan => name -> plan
     }
+
+  def identifier: Parser[Name] = quotedIdent | unquotedIdent
 
   private def queryNoWith: Parser[LogicalPlan] =
     queryTerm ~ queryOrganization ^^ { case p ~ f => f(p) }
@@ -169,7 +196,7 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
     rep1sep(projection | star, ",")
 
   private def projection: Parser[NamedExpression] =
-    expression ~ (AS.? ~> ident).? ^^ {
+    expression ~ (AS.? ~> identifier).? ^^ {
       case e ~ Some(a) => e as a
       case e ~ _       => named(e)
     }
@@ -241,7 +268,7 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
   )
 
   private def function: Parser[Expression] =
-    ident ~ ("(" ~> functionArgs <~ ")") ^^ {
+    identifier ~ ("(" ~> functionArgs <~ ")") ^^ {
       case functionName ~ ((distinct, args)) =>
         UnresolvedFunction(functionName, args, distinct)
     }
@@ -252,7 +279,7 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
   )
 
   private def attribute: Parser[UnresolvedAttribute] =
-    (ident <~ ".").? ~ ident ^^ {
+    (identifier <~ ".").? ~ identifier ^^ {
       case qualifier ~ name => UnresolvedAttribute(name, qualifier)
     }
 
@@ -327,12 +354,12 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
     STRUCT ~ "<" ~> rep1sep(structField, ",") <~ ">" ^^ (StructType(_))
 
   private def structField: Parser[StructField] =
-    ident ~ (":" ~> dataType) ^^ {
+    identifier ~ (":" ~> dataType) ^^ {
       case i ~ t => StructField(i, t.?)
     }
 
   private def star: Parser[Star] =
-    (ident <~ ".").? <~ "*" ^^ Star
+    (identifier <~ ".").? <~ "*" ^^ Star
 
   private def relations: Parser[LogicalPlan] =
     relation * ("," ^^^ (Join(_: LogicalPlan, _: LogicalPlan, Inner, None)))
@@ -350,11 +377,11 @@ class Parser(settings: Settings) extends TokenParser[LogicalPlan] {
     }
 
   private def relationFactor: Parser[LogicalPlan] = (
-    ident ~ (AS.? ~> ident.?) ^^ {
+    identifier ~ (AS.? ~> identifier.?) ^^ {
       case t ~ Some(a) => UnresolvedRelation(t) subquery a
       case t ~ None    => UnresolvedRelation(t)
     }
-    | ("(" ~> queryNoWith <~ ")") ~ (AS.? ~> ident) ^^ {
+    | ("(" ~> queryNoWith <~ ")") ~ (AS.? ~> identifier) ^^ {
       case s ~ a => s subquery a
     }
   )
@@ -432,7 +459,7 @@ class Lexical(keywords: Set[String]) extends StdLexical with Tokens {
 
     // Back-quoted identifiers
     | '`' ~> (chrExcept('`', '\n', EofCh) | ('`' ~ '`') ^^^ '`').* <~ '`' ^^ {
-      case cs => Identifier(cs.mkString)
+      case cs => QuotedIdentifier(cs.mkString)
     }
 
     // Integral and fractional numeric literals
@@ -485,6 +512,6 @@ class Lexical(keywords: Set[String]) extends StdLexical with Tokens {
 
   override protected def processIdent(name: String) = {
     val lowerCased = name.toLowerCase
-    if (reserved contains lowerCased) Keyword(lowerCased) else Identifier(name)
+    if (reserved contains lowerCased) Keyword(lowerCased) else UnquotedIdentifier(name)
   }
 }

--- a/core/src/main/scala/scraper/parser/Parser.scala
+++ b/core/src/main/scala/scraper/parser/Parser.scala
@@ -8,7 +8,7 @@ import scala.util.parsing.combinator.token.StdTokens
 import scala.util.parsing.input.CharArrayReader.EofCh
 
 import scraper.Name
-import scraper.Name.{ci, cs}
+import scraper.Name.{caseInsensitive, caseSensitive}
 import scraper.config.Settings
 import scraper.exceptions.ParsingException
 import scraper.expressions._
@@ -51,12 +51,12 @@ abstract class TokenParser[T] extends StdTokenParsers {
 
   def quotedIdent: Parser[Name] =
     elem("quoted identifier", _.isInstanceOf[QuotedIdentifier]) ^^ {
-      token => cs(token.chars)
+      token => caseSensitive(token.chars)
     }
 
   def unquotedIdent: Parser[Name] =
     elem("unquoted identifier", _.isInstanceOf[UnquotedIdentifier]) ^^ {
-      token => ci(token.chars)
+      token => caseInsensitive(token.chars)
     }
 
   protected case class Keyword(name: String) {

--- a/core/src/main/scala/scraper/plans/logical/Analyzer.scala
+++ b/core/src/main/scala/scraper/plans/logical/Analyzer.scala
@@ -1,7 +1,6 @@
 package scraper.plans.logical
 
-import scraper.{Catalog, Name}
-import scraper.Name.ci
+import scraper._
 import scraper.exceptions.{AnalysisException, IllegalAggregationException, ResolutionFailureException}
 import scraper.expressions._
 import scraper.expressions.AutoAlias.AnonymousColumnName
@@ -229,7 +228,7 @@ class Analyzer(catalog: Catalog) extends RulesExecutor[LogicalPlan] {
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
     override def apply(tree: LogicalPlan): LogicalPlan = tree transformAllExpressions {
-      case UnresolvedFunction(name, (_: Star) :: Nil, false) if name == ci("count") =>
+      case UnresolvedFunction(name, (_: Star) :: Nil, false) if name == ci"count" =>
         Count(1)
 
       case UnresolvedFunction(_, (_: Star) :: Nil, true) =>

--- a/core/src/main/scala/scraper/plans/logical/Analyzer.scala
+++ b/core/src/main/scala/scraper/plans/logical/Analyzer.scala
@@ -1,11 +1,11 @@
 package scraper.plans.logical
 
-import scraper.Catalog
+import scraper.{Catalog, Name}
 import scraper.exceptions.{AnalysisException, IllegalAggregationException, ResolutionFailureException}
 import scraper.expressions._
-import scraper.expressions.dsl._
 import scraper.expressions.AutoAlias.AnonymousColumnName
 import scraper.expressions.NamedExpression.{newExpressionID, UnquotedName}
+import scraper.expressions.dsl._
 import scraper.plans.logical.dsl._
 import scraper.plans.logical.patterns._
 import scraper.trees.{Rule, RulesExecutor}
@@ -89,7 +89,7 @@ class Analyzer(catalog: Catalog) extends RulesExecutor[LogicalPlan] {
         })
     }
 
-    private def expand(maybeQualifier: Option[String], input: Seq[Attribute]): Seq[Attribute] =
+    private def expand(maybeQualifier: Option[Name], input: Seq[Attribute]): Seq[Attribute] =
       maybeQualifier map { qualifier =>
         input collect {
           case ref: AttributeRef if ref.qualifier contains qualifier => ref
@@ -226,8 +226,10 @@ class Analyzer(catalog: Catalog) extends RulesExecutor[LogicalPlan] {
    * up function names from the [[Catalog]].
    */
   object ResolveFunctions extends Rule[LogicalPlan] {
+    import scraper.Name._
+
     override def apply(tree: LogicalPlan): LogicalPlan = tree transformAllExpressions {
-      case UnresolvedFunction(name, (_: Star) :: Nil, false) if name.toLowerCase == "count" =>
+      case UnresolvedFunction(name, (_: Star) :: Nil, false) if name == ci("count") =>
         Count(1)
 
       case UnresolvedFunction(_, (_: Star) :: Nil, true) =>

--- a/core/src/main/scala/scraper/plans/logical/LogicalPlan.scala
+++ b/core/src/main/scala/scraper/plans/logical/LogicalPlan.scala
@@ -4,7 +4,7 @@ import scala.reflect.runtime.universe.WeakTypeTag
 import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 
-import scraper.Row
+import scraper.{Name, Row}
 import scraper.annotations.Explain
 import scraper.exceptions.{LogicalPlanUnresolvedException, TypeCheckException}
 import scraper.expressions._
@@ -81,7 +81,7 @@ trait MultiInstanceRelation extends Relation {
   def newInstance(): LogicalPlan
 }
 
-case class UnresolvedRelation(name: String) extends Relation with UnresolvedLogicalPlan
+case class UnresolvedRelation(name: Name) extends Relation with UnresolvedLogicalPlan
 
 case object SingleRowRelation extends Relation {
   override val output: Seq[Attribute] = Nil
@@ -258,7 +258,7 @@ case class Join(
     predicates reduceOption And map on getOrElse this
 }
 
-case class Subquery(child: LogicalPlan, alias: String) extends UnaryLogicalPlan {
+case class Subquery(child: LogicalPlan, alias: Name) extends UnaryLogicalPlan {
   override lazy val output: Seq[Attribute] = child.output map {
     case a: AttributeRef => a.copy(qualifier = Some(alias))
     case a: Attribute    => a
@@ -291,7 +291,7 @@ case class Sort(child: LogicalPlan, order: Seq[SortOrder]) extends UnaryLogicalP
 
 case class With(
   child: LogicalPlan,
-  name: String,
+  name: Name,
   @Explain(hidden = true, nestedTree = true) cteRelation: LogicalPlan
 ) extends UnaryLogicalPlan {
   override def output: Seq[Attribute] = child.output

--- a/core/src/main/scala/scraper/plans/logical/dsl/package.scala
+++ b/core/src/main/scala/scraper/plans/logical/dsl/package.scala
@@ -1,5 +1,6 @@
 package scraper.plans.logical
 
+import scraper.Name
 import scraper.expressions._
 import scraper.expressions.AutoAlias.named
 import scraper.expressions.functions._
@@ -8,8 +9,8 @@ package object dsl {
   implicit class LogicalPlanDSL(plan: LogicalPlan) {
     def select(projectList: Seq[Expression]): Project =
       Project(plan, projectList map {
-        case UnresolvedAttribute("*", qualifier) => Star(qualifier)
-        case e                                   => named(e)
+        case UnresolvedAttribute(name, qualifier) if name.casePreserving == "*" => Star(qualifier)
+        case e => named(e)
       })
 
     def select(first: Expression, rest: Expression*): Project = select(first +: rest)
@@ -36,9 +37,11 @@ package object dsl {
 
     def distinct: Distinct = Distinct(plan)
 
-    def subquery(name: String): Subquery = Subquery(plan, name)
+    def subquery(name: Name): Subquery = Subquery(plan, name)
 
-    def subquery(name: Symbol): Subquery = plan subquery name.name
+    def subquery(name: String): Subquery = plan subquery Name.cs(name)
+
+    def subquery(name: Symbol): Subquery = plan subquery Name.ci(name.name)
 
     def join(that: LogicalPlan): Join = Join(plan, that, Inner, None)
 
@@ -97,9 +100,11 @@ package object dsl {
     def agg(first: AggregationAlias, rest: AggregationAlias*): Aggregate = agg(first +: rest)
   }
 
-  def table(name: String): UnresolvedRelation = UnresolvedRelation(name)
+  def table(name: Name): UnresolvedRelation = UnresolvedRelation(name)
 
-  def table(name: Symbol): UnresolvedRelation = table(name.name)
+  def table(name: String): UnresolvedRelation = table(Name.cs(name))
+
+  def table(name: Symbol): UnresolvedRelation = table(Name.ci(name.name))
 
   def values(expressions: Seq[Expression]): Project = SingleRowRelation select expressions
 
@@ -107,6 +112,6 @@ package object dsl {
 
   def let(cteRelation: (Symbol, LogicalPlan))(body: LogicalPlan): With = {
     val (name, value) = cteRelation
-    With(body, name.name, value)
+    With(body, Name.ci(name.name), value)
   }
 }

--- a/core/src/main/scala/scraper/plans/logical/dsl/package.scala
+++ b/core/src/main/scala/scraper/plans/logical/dsl/package.scala
@@ -39,10 +39,6 @@ package object dsl {
 
     def subquery(name: Name): Subquery = Subquery(plan, name)
 
-    def subquery(name: String): Subquery = plan subquery Name.cs(name)
-
-    def subquery(name: Symbol): Subquery = plan subquery Name.ci(name.name)
-
     def join(that: LogicalPlan): Join = Join(plan, that, Inner, None)
 
     def leftSemiJoin(that: LogicalPlan): Join = Join(plan, that, LeftSemi, None)
@@ -102,16 +98,12 @@ package object dsl {
 
   def table(name: Name): UnresolvedRelation = UnresolvedRelation(name)
 
-  def table(name: String): UnresolvedRelation = table(Name.cs(name))
-
-  def table(name: Symbol): UnresolvedRelation = table(Name.ci(name.name))
-
   def values(expressions: Seq[Expression]): Project = SingleRowRelation select expressions
 
   def values(first: Expression, rest: Expression*): Project = values(first +: rest)
 
   def let(cteRelation: (Symbol, LogicalPlan))(body: LogicalPlan): With = {
     val (name, value) = cteRelation
-    With(body, Name.ci(name.name), value)
+    With(body, name, value)
   }
 }

--- a/core/src/main/scala/scraper/reflection/package.scala
+++ b/core/src/main/scala/scraper/reflection/package.scala
@@ -37,7 +37,7 @@ package object reflection {
       StructType(params.map { param =>
         val paramType = param.typeSignature.substituteTypes(formalTypeArgs, actualTypeArgs)
         val FieldSpec(dataType, nullable) = fieldSpecFor(paramType)
-        StructField(Name.cs(param.name.toString), dataType, nullable)
+        StructField(param.name.toString, dataType, nullable)
       }).?
   }
 

--- a/core/src/main/scala/scraper/reflection/package.scala
+++ b/core/src/main/scala/scraper/reflection/package.scala
@@ -37,7 +37,7 @@ package object reflection {
       StructType(params.map { param =>
         val paramType = param.typeSignature.substituteTypes(formalTypeArgs, actualTypeArgs)
         val FieldSpec(dataType, nullable) = fieldSpecFor(paramType)
-        StructField(param.name.toString, dataType, nullable)
+        StructField(Name.cs(param.name.toString), dataType, nullable)
       }).?
   }
 

--- a/core/src/main/scala/scraper/types/complexTypes.scala
+++ b/core/src/main/scala/scraper/types/complexTypes.scala
@@ -121,7 +121,7 @@ case class StructType(fields: Seq[StructField] = Seq.empty) extends ComplexType 
 
   override def sql: String = {
     val fieldsString = fields map { f =>
-      s"${quote(f.name.casePreserving)}: ${f.dataType.sql}"
+      s"${quote(f.name.toString)}: ${f.dataType.sql}"
     } mkString ", "
 
     s"STRUCT<$fieldsString>"

--- a/core/src/main/scala/scraper/types/complexTypes.scala
+++ b/core/src/main/scala/scraper/types/complexTypes.scala
@@ -67,23 +67,22 @@ object StructField {
 
   implicit def `(String,DataType)->StructField`(pair: (String, DataType)): StructField =
     pair match {
-      case (name, dataType) => StructField(Name.ci(name), dataType, nullable = true)
+      case (name, dataType) => StructField(name, dataType, nullable = true)
     }
 
   implicit def `(Symbol,DataType)->StructField`(pair: (Symbol, DataType)): StructField =
     pair match {
-      case (name, dataType) =>
-        StructField(Name.ci(name.name), dataType, nullable = true)
+      case (name, dataType) => StructField(name, dataType, nullable = true)
     }
 
   implicit def `(String,FieldSpec)->StructField`(pair: (String, FieldSpec)): StructField =
     pair match {
-      case (name, fieldSpec) => StructField(Name.ci(name), fieldSpec)
+      case (name, fieldSpec) => StructField(name, fieldSpec)
     }
 
   implicit def `(Symbol,FieldSpec)->StructField`(pair: (Symbol, FieldSpec)): StructField =
     pair match {
-      case (name, fieldSpec) => StructField(Name.ci(name.name), fieldSpec)
+      case (name, fieldSpec) => StructField(name, fieldSpec)
     }
 }
 
@@ -118,8 +117,7 @@ case class StructType(fields: Seq[StructField] = Seq.empty) extends ComplexType 
     })
   }
 
-  def rename(firstName: String, restNames: String*): StructType =
-    this rename (firstName +: restNames map Name.ci)
+  def rename(firstName: Name, restNames: Name*): StructType = this rename (firstName +: restNames)
 
   override def sql: String = {
     val fieldsString = fields map { f =>

--- a/core/src/test/scala/scraper/DataFrameSuite.scala
+++ b/core/src/test/scala/scraper/DataFrameSuite.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 import org.scalatest.BeforeAndAfterAll
 
-import scraper.Name.ci
+import scraper.Name.caseInsensitive
 import scraper.exceptions.ResolutionFailureException
 import scraper.expressions.dsl._
 import scraper.expressions.functions._

--- a/core/src/test/scala/scraper/DataFrameSuite.scala
+++ b/core/src/test/scala/scraper/DataFrameSuite.scala
@@ -22,8 +22,8 @@ class DataFrameSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterA
   private val r2 = LocalRelation(Nil, 'a.int.! :: 'b.string.? :: Nil)
 
   override protected def beforeAll(): Unit = {
-    context.catalog.registerRelation(ci("t"), r1)
-    context.catalog.registerRelation(ci("s"), r2)
+    context.catalog.registerRelation('t, r1)
+    context.catalog.registerRelation('s, r2)
   }
 
   test("column") {
@@ -163,7 +163,7 @@ class DataFrameSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterA
   }
 
   test("asTable") {
-    withTable(ci("reverse")) {
+    withTable('reverse) {
       val df = table('t) orderBy 'a.desc
       df asTable 'reverse
 

--- a/core/src/test/scala/scraper/DataFrameSuite.scala
+++ b/core/src/test/scala/scraper/DataFrameSuite.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 import org.scalatest.BeforeAndAfterAll
 
+import scraper.Name.ci
 import scraper.exceptions.ResolutionFailureException
 import scraper.expressions.dsl._
 import scraper.expressions.functions._
@@ -21,8 +22,8 @@ class DataFrameSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterA
   private val r2 = LocalRelation(Nil, 'a.int.! :: 'b.string.? :: Nil)
 
   override protected def beforeAll(): Unit = {
-    context.catalog.registerRelation("t", r1)
-    context.catalog.registerRelation("s", r2)
+    context.catalog.registerRelation(ci("t"), r1)
+    context.catalog.registerRelation(ci("s"), r2)
   }
 
   test("column") {
@@ -162,7 +163,7 @@ class DataFrameSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterA
   }
 
   test("asTable") {
-    withTable("reverse") {
+    withTable(ci("reverse")) {
       val df = table('t) orderBy 'a.desc
       df asTable 'reverse
 

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -9,6 +9,22 @@ import org.scalatest.prop.Checkers
 import scraper.Name.{caseInsensitive, caseSensitive}
 
 class NameSuite extends LoggingFunSuite with Checkers {
+  test("basic properties") {
+    check {
+      forAll(alphaStr) { name =>
+        all(
+          caseSensitive(name).isCaseSensitive,
+
+          !caseInsensitive(name).isCaseSensitive,
+
+          caseSensitive(name).casePreserving == name,
+
+          caseInsensitive(name).casePreserving == name
+        )
+      }
+    }
+  }
+
   test("equality") {
     check {
       forAll(alphaStr) { name =>
@@ -22,7 +38,13 @@ class NameSuite extends LoggingFunSuite with Checkers {
                 caseSensitive(name.toLowerCase) != caseInsensitive(name),
 
               "inequality: case-sensitive v.s. case-sensitive" |:
-                caseSensitive(name.toLowerCase) != caseSensitive(name)
+                caseSensitive(name.toLowerCase) != caseSensitive(name),
+
+              "inequality: case-sensitive v.s. other classes" |:
+                caseSensitive(name) != (name: Any),
+
+              "inequality: case-insensitive v.s. other classes" |:
+                caseSensitive(name) != (name: Any)
             ),
 
           "equality: case-sensitive v.s. case-sensitive" |:

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -10,53 +10,38 @@ import scraper.Name.{caseInsensitive, caseSensitive}
 
 class NameSuite extends LoggingFunSuite with Checkers {
   test("equality") {
-    check(all(
+    check {
       forAll(alphaStr) { name =>
-        (name != name.toLowerCase) ==> {
-          "inequality: case-insensitive v.s. case-sensitive" |:
-            caseInsensitive(name.toLowerCase) != caseSensitive(name)
-        }
-      },
+        all(
+          (name != name.toLowerCase) ==>
+            all(
+              "inequality: case-insensitive v.s. case-sensitive" |:
+                caseInsensitive(name.toLowerCase) != caseSensitive(name),
 
-      forAll(alphaStr) { name =>
-        (name != name.toLowerCase) ==> {
-          "inequality: case-sensitive v.s. case-insensitive" |:
-            caseSensitive(name.toLowerCase) != caseInsensitive(name)
-        }
-      },
+              "inequality: case-sensitive v.s. case-insensitive" |:
+                caseSensitive(name.toLowerCase) != caseInsensitive(name),
 
-      forAll(alphaStr) { name =>
-        (name != name.toLowerCase) ==> {
-          "inequality: case-sensitive v.s. case-sensitive" |:
-            caseSensitive(name.toLowerCase) != caseSensitive(name)
-        }
-      },
+              "inequality: case-sensitive v.s. case-sensitive" |:
+                caseSensitive(name.toLowerCase) != caseSensitive(name)
+            ),
 
-      forAll(alphaStr) { name =>
-        "equality: case-sensitive v.s. case-sensitive" |:
-          caseSensitive(name) == caseSensitive(name)
-      },
+          "equality: case-sensitive v.s. case-sensitive" |:
+            caseSensitive(name) == caseSensitive(name),
 
-      forAll(alphaStr) { name =>
-        "equality: case-sensitive v.s. case-insensitive" |:
-          caseSensitive(name) == caseInsensitive(name)
-      },
+          "equality: case-sensitive v.s. case-insensitive" |:
+            caseSensitive(name) == caseInsensitive(name),
 
-      forAll(alphaStr) { name =>
-        "equality: case-insensitive v.s. case-sensitive" |:
-          caseInsensitive(name) == caseSensitive(name)
-      },
+          "equality: case-insensitive v.s. case-sensitive" |:
+            caseInsensitive(name) == caseSensitive(name),
 
-      forAll(alphaStr) { name =>
-        "equality: case-insensitive v.s. case-insensitive (in the same case)" |:
-          caseInsensitive(name) == caseInsensitive(name)
-      },
+          "equality: case-insensitive v.s. case-insensitive (in the same case)" |:
+            caseInsensitive(name) == caseInsensitive(name),
 
-      forAll(alphaStr) { name =>
-        "equality: case-insensitive v.s. case-insensitive (in different cases)" |:
-          caseInsensitive(name) == caseInsensitive(name.toLowerCase)
+          "equality: case-insensitive v.s. case-insensitive (in different cases)" |:
+            caseInsensitive(name) == caseInsensitive(name.toLowerCase)
+        )
       }
-    ))
+    }
   }
 
   test("hashCode and equals contract") {

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -11,48 +11,48 @@ import scraper.Name.{caseInsensitive, caseSensitive}
 class NameSuite extends LoggingFunSuite with Checkers {
   test("equality") {
     check(all(
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         (name != name.toLowerCase) ==> {
           "inequality: case-insensitive v.s. case-sensitive" |:
             caseInsensitive(name.toLowerCase) != caseSensitive(name)
         }
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         (name != name.toLowerCase) ==> {
           "inequality: case-sensitive v.s. case-insensitive" |:
             caseSensitive(name.toLowerCase) != caseInsensitive(name)
         }
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         (name != name.toLowerCase) ==> {
           "inequality: case-sensitive v.s. case-sensitive" |:
             caseSensitive(name.toLowerCase) != caseSensitive(name)
         }
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         "equality: case-sensitive v.s. case-sensitive" |:
           caseSensitive(name) == caseSensitive(name)
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         "equality: case-sensitive v.s. case-insensitive" |:
           caseSensitive(name) == caseInsensitive(name)
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         "equality: case-insensitive v.s. case-sensitive" |:
           caseInsensitive(name) == caseSensitive(name)
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         "equality: case-insensitive v.s. case-insensitive (in the same case)" |:
           caseInsensitive(name) == caseInsensitive(name)
       },
 
-      forAll(alphaStr) { name: String =>
+      forAll(alphaStr) { name =>
         "equality: case-insensitive v.s. case-insensitive (in different cases)" |:
           caseInsensitive(name) == caseInsensitive(name.toLowerCase)
       }
@@ -67,10 +67,33 @@ class NameSuite extends LoggingFunSuite with Checkers {
 
     check {
       forAll(genName, genName) {
-        case (lhs: Name, rhs: Name) if lhs == rhs => lhs.## == rhs.##
         case (lhs: Name, rhs: Name) if lhs.## != rhs.## => lhs != rhs
+        // TODO Probability of reaching this branch is too small, can't be well tested
+        case (lhs: Name, rhs: Name) if lhs == rhs => lhs.## == rhs.##
         case _ => true
       }
     }
+  }
+
+  test("interpolation") {
+    val caseSensitive = cs"Hello"
+    val caseInsensitive = ci"Hello"
+
+    assert(caseSensitive.isCaseSensitive)
+    assert(caseSensitive.casePreserving == "Hello")
+
+    assert(!caseInsensitive.isCaseSensitive)
+    assert(caseInsensitive.casePreserving == "Hello")
+  }
+
+  test("implicit conversion") {
+    val caseSensitive: Name = "Hello"
+    val caseInsensitive: Name = 'Hello
+
+    assert(caseSensitive.isCaseSensitive)
+    assert(caseSensitive.casePreserving == "Hello")
+
+    assert(!caseInsensitive.isCaseSensitive)
+    assert(caseInsensitive.casePreserving == "Hello")
   }
 }

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -9,13 +9,13 @@ import org.scalatest.prop.Checkers
 import scraper.Name.{caseInsensitive, caseSensitive}
 
 class NameSuite extends LoggingFunSuite with Checkers {
-  test("comparison") {
+  test("equality") {
     check(all(
       forAll(alphaStr) { name: String =>
         "case-sensitive v.s. case-sensitive" |: {
           val lhs = caseSensitive(name)
           val rhs = caseSensitive(name)
-          lhs == rhs && lhs.## == rhs.##
+          lhs == rhs
         }
       },
 
@@ -23,7 +23,7 @@ class NameSuite extends LoggingFunSuite with Checkers {
         "case-sensitive v.s. case-insensitive" |: {
           val lhs = caseSensitive(name)
           val rhs = caseInsensitive(name)
-          lhs == rhs && lhs.## == rhs.##
+          lhs == rhs
         }
       },
 
@@ -31,7 +31,7 @@ class NameSuite extends LoggingFunSuite with Checkers {
         "case-insensitive v.s. case-sensitive" |: {
           val lhs = caseInsensitive(name)
           val rhs = caseSensitive(name)
-          lhs == rhs && lhs.## == rhs.##
+          lhs == rhs
         }
       },
 
@@ -39,7 +39,7 @@ class NameSuite extends LoggingFunSuite with Checkers {
         "case-insensitive v.s. case-insensitive (in the same case)" |: {
           val lhs = caseInsensitive(name)
           val rhs = caseInsensitive(name)
-          lhs == rhs && lhs.## == rhs.##
+          lhs == rhs
         }
       },
 
@@ -47,7 +47,7 @@ class NameSuite extends LoggingFunSuite with Checkers {
         "case-insensitive v.s. case-insensitive (in different cases)" |: {
           val lhs = caseInsensitive(name)
           val rhs = caseInsensitive(name.toLowerCase)
-          lhs == rhs && lhs.## == rhs.##
+          lhs == rhs
         }
       }
     ))

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -1,0 +1,61 @@
+package scraper
+
+import org.scalacheck.Gen.alphaStr
+import org.scalacheck.Prop.{all, forAll, BooleanOperators}
+import org.scalatest.prop.Checkers
+
+import scraper.Name.{caseInsensitive, caseSensitive}
+
+class NameSuite extends LoggingFunSuite with Checkers {
+  test("Name comparison") {
+    check(all(
+      forAll(alphaStr) { name: String =>
+        "case-sensitive v.s. case-sensitive" |:
+          caseSensitive(name) == caseSensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-sensitive v.s. case-insensitive" |:
+          caseSensitive(name) == caseInsensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-insensitive v.s. case-sensitive" |:
+          caseInsensitive(name) == caseSensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-insensitive v.s. case-insensitive" |:
+          caseInsensitive(name) == caseInsensitive(name.toLowerCase)
+      }
+    ))
+  }
+
+  test("Name hashCode") {
+    implicit val arbString = alphaStr
+
+    check(all(
+      forAll(alphaStr) { name: String =>
+        "case-sensitive v.s. case-sensitive" |:
+          (caseSensitive(name).## == caseSensitive(name).##)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-sensitive v.s. case-insensitive" |: {
+          name != name.toLowerCase || caseSensitive(name).## == caseInsensitive(name).##
+        }
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-insensitive v.s. case-sensitive" |: {
+          name != name.toLowerCase || caseInsensitive(name).## == caseSensitive(name).##
+        }
+      },
+
+      forAll(alphaStr) { name: String =>
+        "case-insensitive v.s. case-insensitive" |:
+          caseInsensitive(name).## == caseInsensitive(name.toLowerCase).##
+      }
+    ))
+  }
+}

--- a/core/src/test/scala/scraper/NameSuite.scala
+++ b/core/src/test/scala/scraper/NameSuite.scala
@@ -12,43 +12,49 @@ class NameSuite extends LoggingFunSuite with Checkers {
   test("equality") {
     check(all(
       forAll(alphaStr) { name: String =>
-        "case-sensitive v.s. case-sensitive" |: {
-          val lhs = caseSensitive(name)
-          val rhs = caseSensitive(name)
-          lhs == rhs
+        (name != name.toLowerCase) ==> {
+          "inequality: case-insensitive v.s. case-sensitive" |:
+            caseInsensitive(name.toLowerCase) != caseSensitive(name)
         }
       },
 
       forAll(alphaStr) { name: String =>
-        "case-sensitive v.s. case-insensitive" |: {
-          val lhs = caseSensitive(name)
-          val rhs = caseInsensitive(name)
-          lhs == rhs
+        (name != name.toLowerCase) ==> {
+          "inequality: case-sensitive v.s. case-insensitive" |:
+            caseSensitive(name.toLowerCase) != caseInsensitive(name)
         }
       },
 
       forAll(alphaStr) { name: String =>
-        "case-insensitive v.s. case-sensitive" |: {
-          val lhs = caseInsensitive(name)
-          val rhs = caseSensitive(name)
-          lhs == rhs
+        (name != name.toLowerCase) ==> {
+          "inequality: case-sensitive v.s. case-sensitive" |:
+            caseSensitive(name.toLowerCase) != caseSensitive(name)
         }
       },
 
       forAll(alphaStr) { name: String =>
-        "case-insensitive v.s. case-insensitive (in the same case)" |: {
-          val lhs = caseInsensitive(name)
-          val rhs = caseInsensitive(name)
-          lhs == rhs
-        }
+        "equality: case-sensitive v.s. case-sensitive" |:
+          caseSensitive(name) == caseSensitive(name)
       },
 
       forAll(alphaStr) { name: String =>
-        "case-insensitive v.s. case-insensitive (in different cases)" |: {
-          val lhs = caseInsensitive(name)
-          val rhs = caseInsensitive(name.toLowerCase)
-          lhs == rhs
-        }
+        "equality: case-sensitive v.s. case-insensitive" |:
+          caseSensitive(name) == caseInsensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "equality: case-insensitive v.s. case-sensitive" |:
+          caseInsensitive(name) == caseSensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "equality: case-insensitive v.s. case-insensitive (in the same case)" |:
+          caseInsensitive(name) == caseInsensitive(name)
+      },
+
+      forAll(alphaStr) { name: String =>
+        "equality: case-insensitive v.s. case-insensitive (in different cases)" |:
+          caseInsensitive(name) == caseInsensitive(name.toLowerCase)
       }
     ))
   }

--- a/core/src/test/scala/scraper/TestUtils.scala
+++ b/core/src/test/scala/scraper/TestUtils.scala
@@ -189,10 +189,10 @@ trait TestUtils { this: FunSuite =>
     }
   }
 
-  def withTable(context: Context, name: String)(f: => Unit): Unit = try f finally {
+  def withTable(context: Context, name: Name)(f: => Unit): Unit = try f finally {
     context.catalog.removeRelation(name)
   }
 
-  def withTable(name: String)(f: => Unit)(implicit context: Context): Unit =
+  def withTable(name: Name)(f: => Unit)(implicit context: Context): Unit =
     withTable(context, name)(f)
 }

--- a/core/src/test/scala/scraper/generators/types/package.scala
+++ b/core/src/test/scala/scraper/generators/types/package.scala
@@ -3,7 +3,7 @@ package scraper.generators
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 
-import scraper.Name
+import scraper.Name.caseInsensitive
 import scraper.Test._
 import scraper.config.Settings
 import scraper.generators.Keys._
@@ -125,7 +125,7 @@ package object types {
         fieldSpecs <- Gen.listOfN(fieldNum, genFieldSpec)
 
         fields = fieldSpecs.zipWithIndex map {
-          case (fieldSpec, ordinal) => StructField(Name.ci(s"c$ordinal"), fieldSpec)
+          case (fieldSpec, ordinal) => StructField(caseInsensitive(s"c$ordinal"), fieldSpec)
         }
       } yield StructType(fields))
   }

--- a/core/src/test/scala/scraper/generators/types/package.scala
+++ b/core/src/test/scala/scraper/generators/types/package.scala
@@ -3,6 +3,7 @@ package scraper.generators
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 
+import scraper.Name
 import scraper.Test._
 import scraper.config.Settings
 import scraper.generators.Keys._
@@ -124,7 +125,7 @@ package object types {
         fieldSpecs <- Gen.listOfN(fieldNum, genFieldSpec)
 
         fields = fieldSpecs.zipWithIndex map {
-          case (fieldSpec, ordinal) => StructField(s"c$ordinal", fieldSpec)
+          case (fieldSpec, ordinal) => StructField(Name.ci(s"c$ordinal"), fieldSpec)
         }
       } yield StructType(fields))
   }

--- a/core/src/test/scala/scraper/parser/LexicalSuite.scala
+++ b/core/src/test/scala/scraper/parser/LexicalSuite.scala
@@ -19,9 +19,9 @@ class LexicalSuite extends LoggingFunSuite with TestUtils {
   }
 
   test("identifier") {
-    checkToken("id", testLexical.Identifier("id"))
-    checkToken("`id`", testLexical.Identifier("id"))
-    checkToken("`i d`", testLexical.Identifier("i d"))
-    checkToken("`i``d`", testLexical.Identifier("i`d"))
+    checkToken("id", testLexical.UnquotedIdentifier("id"))
+    checkToken("`id`", testLexical.QuotedIdentifier("id"))
+    checkToken("`i d`", testLexical.QuotedIdentifier("i d"))
+    checkToken("`i``d`", testLexical.QuotedIdentifier("i`d"))
   }
 }

--- a/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
+++ b/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
@@ -3,7 +3,6 @@ package scraper.plans.logical
 import org.scalatest.BeforeAndAfterAll
 
 import scraper._
-import scraper.Name.{ci, cs}
 import scraper.exceptions.{IllegalAggregationException, ResolutionFailureException}
 import scraper.expressions._
 import scraper.expressions.NamedExpression.newExpressionID
@@ -36,6 +35,9 @@ class AnalyzerSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterAl
   }
 
   testAlias('a + 1, "(a + 1)")
+
+  // Case-insensitive name resolution
+  testAlias('B + 1, "(b + 1)")
 
   testAlias($"t.a" + 1, "(a + 1)")
 
@@ -323,10 +325,10 @@ class AnalyzerSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterAl
   private def checkAnalyzedPlan(unresolved: LogicalPlan, expected: LogicalPlan): Unit =
     checkPlan(analyze(unresolved), expected)
 
-  private def testAlias(expression: Expression, expectedAlias: String): Unit = {
-    test(s"auto-alias resolution - $expression AS ${quote(expectedAlias)}") {
+  private def testAlias(expression: Expression, expectedAlias: Name): Unit = {
+    test(s"auto-alias resolution - $expression AS ${quote(expectedAlias.toString)}") {
       val Seq(actualAlias) = analyze(relation subquery 't select expression).output map (_.name)
-      assert(actualAlias == cs(expectedAlias))
+      assert(actualAlias == expectedAlias)
     }
   }
 }

--- a/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
+++ b/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
@@ -3,6 +3,7 @@ package scraper.plans.logical
 import org.scalatest.BeforeAndAfterAll
 
 import scraper._
+import scraper.Name.{ci, cs}
 import scraper.exceptions.{IllegalAggregationException, ResolutionFailureException}
 import scraper.expressions._
 import scraper.expressions.NamedExpression.newExpressionID
@@ -31,7 +32,7 @@ class AnalyzerSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterAl
   private val relation = LocalRelation.empty(a, b)
 
   override protected def beforeAll(): Unit = {
-    catalog.registerRelation("t", relation)
+    catalog.registerRelation(ci("t"), relation)
   }
 
   testAlias('a + 1, "(a + 1)")
@@ -325,7 +326,7 @@ class AnalyzerSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterAl
   private def testAlias(expression: Expression, expectedAlias: String): Unit = {
     test(s"auto-alias resolution - $expression AS ${quote(expectedAlias)}") {
       val Seq(actualAlias) = analyze(relation subquery 't select expression).output map (_.name)
-      assert(actualAlias == expectedAlias)
+      assert(actualAlias == cs(expectedAlias))
     }
   }
 }

--- a/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
+++ b/core/src/test/scala/scraper/plans/logical/AnalyzerSuite.scala
@@ -32,7 +32,7 @@ class AnalyzerSuite extends LoggingFunSuite with TestUtils with BeforeAndAfterAl
   private val relation = LocalRelation.empty(a, b)
 
   override protected def beforeAll(): Unit = {
-    catalog.registerRelation(ci("t"), relation)
+    catalog.registerRelation('t, relation)
   }
 
   testAlias('a + 1, "(a + 1)")

--- a/core/src/test/scala/scraper/types/DataTypeSuite.scala
+++ b/core/src/test/scala/scraper/types/DataTypeSuite.scala
@@ -11,8 +11,6 @@ import scraper.expressions.dsl._
 import scraper.generators.types._
 
 class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
-  import scraper.Name._
-
   // ScalaCheck pretty printing support for `DataType`
   private implicit def prettyDataType(dataType: DataType): Pretty = Pretty {
     _ => "\n" + dataType.prettyTree
@@ -72,14 +70,14 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
 
   test("StructType instantiation") {
     checkTree(
-      StructType(StructField(ci("f1"), IntType, nullable = false) :: Nil),
+      StructType(StructField('f1, IntType, nullable = false) :: Nil),
       StructType('f1 -> IntType.!)
     )
 
     checkTree(
       StructType(Seq(
-        StructField(ci("f1"), IntType, nullable = true),
-        StructField(ci("f2"), DoubleType, nullable = false)
+        StructField('f1, IntType, nullable = true),
+        StructField('f2, DoubleType, nullable = false)
       )),
       StructType(
         'f1 -> IntType,

--- a/core/src/test/scala/scraper/types/DataTypeSuite.scala
+++ b/core/src/test/scala/scraper/types/DataTypeSuite.scala
@@ -11,6 +11,8 @@ import scraper.expressions.dsl._
 import scraper.generators.types._
 
 class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
+  import scraper.Name._
+
   // ScalaCheck pretty printing support for `DataType`
   private implicit def prettyDataType(dataType: DataType): Pretty = Pretty {
     _ => "\n" + dataType.prettyTree
@@ -70,14 +72,14 @@ class DataTypeSuite extends LoggingFunSuite with TestUtils with Checkers {
 
   test("StructType instantiation") {
     checkTree(
-      StructType(StructField("f1", IntType, nullable = false) :: Nil),
+      StructType(StructField(ci("f1"), IntType, nullable = false) :: Nil),
       StructType('f1 -> IntType.!)
     )
 
     checkTree(
       StructType(Seq(
-        StructField("f1", IntType, nullable = true),
-        StructField("f2", DoubleType, nullable = false)
+        StructField(ci("f1"), IntType, nullable = true),
+        StructField(ci("f2"), DoubleType, nullable = false)
       )),
       StructType(
         'f1 -> IntType,

--- a/execution/local/src/test/scala/scraper/LocalContextSuite.scala
+++ b/execution/local/src/test/scala/scraper/LocalContextSuite.scala
@@ -2,6 +2,7 @@ package scraper
 
 import scraper.Context._
 import scraper.LocalContextSuite.Person
+import scraper.Name.ci
 import scraper.exceptions.TableNotFoundException
 import scraper.expressions.dsl._
 import scraper.expressions.functions._
@@ -45,7 +46,7 @@ class LocalContextSuite extends LoggingFunSuite with TestUtils {
   }
 
   test("table") {
-    withTable("t") {
+    withTable(ci("t")) {
       context range 2 asTable "t"
 
       checkDataFrame(
@@ -64,7 +65,7 @@ class LocalContextSuite extends LoggingFunSuite with TestUtils {
   )
 
   test("mixed") {
-    people filter 'age =/= 21 asTable "people"
+    people filter 'age =/= 21 asTable 'people
 
     checkDataFrame(
       "SELECT name FROM people".q,
@@ -209,7 +210,7 @@ class LocalContextSuite extends LoggingFunSuite with TestUtils {
   }
 
   test("rand") {
-    withTable("t") {
+    withTable(ci("t")) {
       context range 10 asTable 't
       """SELECT *
         |FROM (

--- a/execution/local/src/test/scala/scraper/LocalContextSuite.scala
+++ b/execution/local/src/test/scala/scraper/LocalContextSuite.scala
@@ -2,7 +2,6 @@ package scraper
 
 import scraper.Context._
 import scraper.LocalContextSuite.Person
-import scraper.Name.ci
 import scraper.exceptions.TableNotFoundException
 import scraper.expressions.dsl._
 import scraper.expressions.functions._
@@ -46,11 +45,11 @@ class LocalContextSuite extends LoggingFunSuite with TestUtils {
   }
 
   test("table") {
-    withTable(ci("t")) {
-      context range 2 asTable "t"
+    withTable('t) {
+      context range 2 asTable 't
 
       checkDataFrame(
-        context table "t",
+        context table 't,
         Row(0), Row(1)
       )
     }
@@ -210,7 +209,7 @@ class LocalContextSuite extends LoggingFunSuite with TestUtils {
   }
 
   test("rand") {
-    withTable(ci("t")) {
+    withTable('t) {
       context range 10 asTable 't
       """SELECT *
         |FROM (


### PR DESCRIPTION
Most SQL implementations support both case-insensitive and case-sensitive name resolution for database name, column names, and function names etc.. Scraper should also support that. Howerever, there are subtle differences between various implementations. The style we adopt here is similar to PostgreSQL: normal names are all case-insensitive, while quoted names are all case-sensitive.
## Case-sensitivity aware `Name`s

This PR introduces a simple class `Name` that can be used to handle both case-sensitive and case-insensitive names, so that we don't have to do random name strings comparisons using different methods (`equals` or `compareToIgnoreCase`) here and there:

``` scala
class Name {
  // Whether this [[Name]] is case-sensitive.
  def isCaseSensitive: Boolean

  // The underlying case-preserving string representation of this [[Name]].
  def casePreserving: String
}

object Name {
  // Builds a case-sensitive [[Name]] using `casePreserving`.
  def caseSensitive(casePreserving: String): Name

  // Builds a case-insensitive [[Name]] using `casePreserving`.
  def caseInsensitive(casePreserving: String): Name

  // Generic constructor.
  def apply(casePreserving: String, isCaseSensitive: Boolean): Name
}
```
## Creating `Name`s

Users can create two kinds of `Name`s:
- case-sensitive ones using `Name.caseSensitive`, and
- case-insensitive ones using `Name.caseInsensitive`

For convenience, `Name`s can also be created using string interpolation:

```
import scraper._

val caseSensitive: Name = cs"Hello"
val caseInsensitive: Name = ci"Hello"
```

and implicit conversions:

``` scala
import scraper._

// Converts String to case-sensitive Name implicitly
val caseSensitive: Name = "Hello"

// Converts String to case-insensitive Name implicitly
val caseInsensitive: Name = 'Hello
```

Note that case-insensitive `Name`s are _case-preserving_:

``` scala
val name1: Name = 'Hello
val name2: Name = 'hello

assert(name1 == name2)
assert(name1.casePreserving == "Hello")
assert(name2.casePreserving == "hello")
```
## Comparing `Name`s

Two `Name`s `lhs` and `rhs` are equal to each other iff:
1. At least one of them is case-sensitive and `lhs.casePreserving == rhs.casePreserving`, or
2. `lhs.casePreserving.compareToIgnoreCase(rhs.casePreserving) == 0` 
## Using `Name`s

With `Name` at hand, now we use it extensively for all kinds of names to support both case-insensitive and case-sensitive name resolution. Specifically, the following classes are all using `Name` instead of plain `String` for naming and name resolution:
1. `NamedExpression.name`
2. `StructField.name`
3. `Catalog`
4. `FunctionRegistry`

The SQL parser is also updated. Unquoted identifiers like `column_name` are parsed as case-insensitive `Name`s, while quoted identifiers like ``column_name`` are parsed as case-sensitive `Name`s.
